### PR TITLE
fix: git push branch

### DIFF
--- a/rollout/gitea/git_operations.go
+++ b/rollout/gitea/git_operations.go
@@ -79,8 +79,8 @@ func createCommit(ctx context.Context, dir string, message string) error {
 	return nil
 }
 
-func pushToOrigin(ctx context.Context, dir string) error {
-	cmd := exec.Command("git", "push", "origin")
+func pushToOrigin(ctx context.Context, dir string, branchName string) error {
+	cmd := exec.Command("git", "push", "origin", branchName)
 	out := new(bytes.Buffer)
 	cmd.Stdout = out
 	cmd.Stderr = out

--- a/rollout/gitea/roll_out_to_gitea.go
+++ b/rollout/gitea/roll_out_to_gitea.go
@@ -50,7 +50,7 @@ func (g *GiteaRollout) RollOut(ctx context.Context, generate func(dir string) er
 		return fmt.Errorf("could not create commit: %w", err)
 	}
 
-	err = pushToOrigin(ctx, td)
+	err = pushToOrigin(ctx, td, branchName)
 	if err != nil {
 		return fmt.Errorf("could not push: %w", err)
 	}


### PR DESCRIPTION
Depending on the user's git config, the current branch doesn't get
pushed unless mentioned explicitly.
