### PR TITLE
build images relative to the project root

### DIFF
--- a/command/images/build/command.go
+++ b/command/images/build/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"sort"
 	"time"
@@ -48,7 +49,7 @@ func Command() *cli.Command {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 				err = docker.Pull(ctx, imageWithTag)
 				if err == docker.ErrImageNotFound {
-					err = docker.BuildGoMod(ctx, image.Go.Package, imageWithTag)
+					err = docker.BuildGoMod(ctx, path.Join(cfg.ProjectRoot, image.Go.Package), imageWithTag)
 					if err != nil {
 						cancel()
 						return err

--- a/image/image.go
+++ b/image/image.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 
 	"github.com/draganm/gosha/gosha"
@@ -78,7 +79,7 @@ func (i *Image) Build(ctx context.Context, projectRoot string) error {
 		return err
 	}
 
-	err = docker.BuildGoMod(ctx, i.Go.Package, imageWithTag)
+	err = docker.BuildGoMod(ctx, path.Join(projectRoot, i.Go.Package), imageWithTag)
 	if err == docker.ErrImageNotFound {
 		return nil
 	}


### PR DESCRIPTION
This allows running `monotool rollout` from a sub-folder and monotool to do the right thing.