### PR TITLE
gitea shallow clones

### DIFF
--- a/rollout/gitea/git_operations.go
+++ b/rollout/gitea/git_operations.go
@@ -9,7 +9,7 @@ import (
 )
 
 func cloneRepo(ctx context.Context, url string, dir string) error {
-	cmd := exec.Command("git", "clone", "-q", url, dir)
+	cmd := exec.Command("git", "clone", "--depth", "1", "--quiet", url, dir)
 	out := new(bytes.Buffer)
 	cmd.Stdout = out
 	cmd.Stderr = out


### PR DESCRIPTION
We only need information about the last commit to prepare the rollout.
Since we clone the repo on every rollout, this should speed things up a
bit.