### PR TITLE
feature: building docker images with nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,129 @@
+# Monotool
+
+A CLI tool for building and deploying containerized applications in a monorepo setup. Monotool automates Docker image building, SHA-based versioning, and deployment through Helm charts and Git operations.
+
+## Getting Started
+
+Initialize a new monotool project:
+
+```bash
+monotool init
+```
+
+This creates a `.monotool/config.yaml` in your current directory.
+
+## Configuration
+
+All configuration lives in `.monotool/config.yaml`. It defines **images** (how to build containers) and **rollouts** (how to deploy them).
+
+```yaml
+images:
+  myservice:
+    dockerImage: registry.example.com/myservice
+    go:
+      package: ./cmd/myservice
+  mynixservice:
+    dockerImage: registry.example.com/mynixservice
+    nix:
+      file: nix/mynixservice.nix
+
+rollouts:
+  production:
+    gitea:
+      repoUrl: https://gitea.example.com/org/deployments.git
+    templates: .monotool/templates
+    targetPath: manifests
+    helmCharts:
+      - repository: https://charts.example.com
+        chart: myapp
+        version: 1.0.0
+        releaseName: myservice
+        namespace: default
+```
+
+## Image Types
+
+Each image must use exactly one build method: `go` or `nix`.
+
+### Go Images
+
+Builds a Docker image from a Go package using `docker buildx`. The image is tagged with a deterministic SHA computed from the Go package source (via [gosha](https://github.com/draganm/gosha)).
+
+```yaml
+images:
+  api:
+    dockerImage: registry.example.com/api
+    go:
+      package: ./cmd/api
+    platform: linux/amd64  # optional, defaults to linux/amd64
+```
+
+The Go build uses a multi-stage Dockerfile: it compiles the Go binary with static linking, then copies it into an Alpine-based image.
+
+### Nix Images
+
+Builds a Docker image using a Nix expression (e.g., `pkgs.dockerTools.buildLayeredImage`). The image is tagged with a hash derived from the Nix derivation, evaluated before building. The resulting tarball is loaded into Docker via `docker load`.
+
+```yaml
+images:
+  worker:
+    dockerImage: registry.example.com/worker
+    nix:
+      file: nix/worker.nix
+```
+
+The `file` path is relative to the project root.
+
+#### Example Nix Expression
+
+Here is an example `nix/worker.nix` that builds a Docker image containing a simple Go binary:
+
+```nix
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  app = pkgs.buildGoModule {
+    pname = "worker";
+    version = "0.1.0";
+    src = ../.;
+    vendorHash = null; # or the appropriate hash
+    subPackages = [ "cmd/worker" ];
+  };
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "worker";
+  tag = "latest";
+  contents = [ app pkgs.cacert ];
+  config = {
+    Entrypoint = [ "${app}/bin/worker" ];
+  };
+}
+```
+
+The Nix expression must evaluate to a Docker image tarball (the output of `dockerTools.buildLayeredImage` or `dockerTools.buildImage`).
+
+## Commands
+
+```bash
+# Initialize a new monotool project
+monotool init
+
+# List all configured images and their build status
+monotool images list
+
+# Build all images that aren't already built
+monotool images build
+
+# Deploy images using a rollout configuration
+monotool rollout [rollout-name]
+```
+
+### Rollout
+
+The `rollout` command builds all images concurrently, pushes them to the registry, then deploys using the configured method (Gitea PR, Helm charts, or both). Image references are passed to rollout templates as `{{ .images.imageName }}`.
+
+## Requirements
+
+- **Go images:** Docker daemon running, `docker` CLI available
+- **Nix images:** `nix-build` and `nix-instantiate` available, Docker daemon running
+- **Rollouts:** `git` in PATH; `tea` CLI for Gitea PR creation

--- a/command/images/build/command.go
+++ b/command/images/build/command.go
@@ -24,7 +24,7 @@ func Command() *cli.Command {
 
 				image := cfg.Images[cn]
 
-				imageName, err := image.DockerImageName(cfg.ProjectRoot)
+				imageName, err := image.DockerImageName(ctx.Context, cfg.ProjectRoot)
 				if err != nil {
 					return fmt.Errorf("could not calculate docker image name for %s: %w", cn, err)
 				}

--- a/command/images/list/command.go
+++ b/command/images/list/command.go
@@ -29,7 +29,7 @@ func Command() *cli.Command {
 
 				fmt.Println(cn + ":")
 
-				imageName, err := image.DockerImageName(cfg.ProjectRoot)
+				imageName, err := image.DockerImageName(ctx, cfg.ProjectRoot)
 				if err != nil {
 					return fmt.Errorf("could not calculate image name: %w", err)
 				}

--- a/command/rollout/command.go
+++ b/command/rollout/command.go
@@ -96,7 +96,7 @@ func Command() *cli.Command {
 					state := atomic.Pointer[string]{}
 					state.Store(pointerOf("initializing"))
 
-					imageName, err := im.DockerImageName(cfg.ProjectRoot)
+					imageName, err := im.DockerImageName(egCtx, cfg.ProjectRoot)
 					if err != nil {
 						return fmt.Errorf("could not calculate docker image of %s: %w", n, err)
 					}

--- a/config/load.go
+++ b/config/load.go
@@ -36,6 +36,17 @@ func Load() (*Config, error) {
 		}
 		cfg.ProjectRoot = dir
 
+		for name, img := range cfg.Images {
+			hasGo := img.Go != nil
+			hasNix := img.Nix != nil
+			if hasGo && hasNix {
+				return nil, fmt.Errorf("image %q has both go and nix configuration, only one is allowed", name)
+			}
+			if !hasGo && !hasNix {
+				return nil, fmt.Errorf("image %q has neither go nor nix configuration, one is required", name)
+			}
+		}
+
 		return cfg, nil
 
 	}

--- a/docs/superpowers/specs/2026-04-04-nix-image-building-design.md
+++ b/docs/superpowers/specs/2026-04-04-nix-image-building-design.md
@@ -1,0 +1,125 @@
+# Nix Image Building for Monotool
+
+## Context
+
+Monotool currently builds Docker images exclusively from Go packages using a Dockerfile template and `docker buildx`. Users who use Nix want to build Docker images via Nix's `dockerTools` (e.g., `buildLayeredImage`) and push them to registries without going through the local Docker daemon. This feature adds a `nix:` image type alongside the existing `go:` image type.
+
+## Design Decisions
+
+- **Config format:** `.nix` file path (relative to project root), not flake attributes
+- **Versioning:** Nix derivation hash from `nix-instantiate`, evaluated before building
+- **Registry interaction:** `skopeo copy` to push directly to registry (no `docker load`)
+- **Exclusivity:** `go:` and `nix:` are mutually exclusive per image definition
+- **Architecture:** Extend existing `Image` struct with a `Nix` field (no interface refactor)
+
+## Configuration
+
+```yaml
+images:
+  myservice:
+    dockerImage: registry.example.com/myservice
+    nix:
+      file: nix/myservice-image.nix
+  goservice:
+    dockerImage: registry.example.com/goservice
+    go:
+      package: ./cmd/goservice
+```
+
+The `nix.file` path is relative to the project root. The `.nix` expression must evaluate to a Docker image (e.g., using `pkgs.dockerTools.buildLayeredImage`).
+
+Validation: config loading rejects images with both `go:` and `nix:` set, or neither set.
+
+## Struct Changes
+
+### `image/image.go`
+
+```go
+type NixImage struct {
+    File string `yaml:"file"`
+}
+
+type Image struct {
+    Go          *GoImage  `yaml:"go"`
+    Nix         *NixImage `yaml:"nix"`
+    DockerImage string    `yaml:"dockerImage"`
+    Platform    string    `yaml:"platform"`
+}
+```
+
+## New Package: `nix/`
+
+A new `nix` package parallel to `docker/` with these functions:
+
+### `nix/instantiate.go`
+- `Instantiate(ctx context.Context, nixFile string) (drvPath string, err error)` — runs `nix-instantiate <nixFile>`, returns the `.drv` store path
+- `DrvHash(drvPath string) string` — extracts the hash from the derivation store path (first 32 chars after `/nix/store/`), truncates to 8 chars for the image tag
+
+### `nix/build.go`
+- `Build(ctx context.Context, nixFile string) (resultPath string, err error)` — runs `nix-build <nixFile>`, returns the `./result` symlink target (the tarball path in the Nix store)
+
+### `nix/skopeo.go`
+- `SkopeoImageExists(ctx context.Context, imageRef string) (bool, error)` — runs `skopeo inspect docker://<imageRef>`, returns true if found
+- `SkopeoCopy(ctx context.Context, archivePath string, imageRef string) error` — runs `skopeo copy docker-archive:<archivePath> docker://<imageRef>`
+
+## Image Method Changes
+
+### `calculateHash(projectRoot string) ([]byte, error)`
+- **Go path (unchanged):** uses gosha
+- **Nix path:** runs `nix-instantiate` on the nix file, extracts derivation hash, returns it as bytes
+
+### `DockerImageName(projectRoot string) (string, error)`
+- **Go path (unchanged):** `dockerImage:gosha-hash[:8]`
+- **Nix path:** `dockerImage:drv-hash[:8]`
+
+### `IsAlreadyBuilt(ctx context.Context, projectRoot string) (bool, error)`
+- **Go path (unchanged):** checks docker locally + registry via manifest inspect
+- **Nix path:** uses `skopeo inspect` to check registry only (no local docker daemon involved)
+
+### `Build(ctx context.Context, projectRoot string) error`
+- **Go path (unchanged):** docker buildx
+- **Nix path:** runs `nix-build`, then `skopeo copy` to push to registry
+
+## Build Flow for Nix Images
+
+```
+1. nix-instantiate nix/myservice.nix
+   -> /nix/store/abc123...xyz-docker-image.drv
+   -> tag = abc12345 (first 8 chars of hash)
+
+2. skopeo inspect docker://registry.example.com/myservice:abc12345
+   -> If found: skip (already built and pushed)
+
+3. nix-build nix/myservice.nix
+   -> /nix/store/def456...-docker-image.tar.gz
+
+4. skopeo copy docker-archive:/nix/store/def456...-docker-image.tar.gz \
+               docker://registry.example.com/myservice:abc12345
+```
+
+## Integration with Rollouts
+
+No changes needed. Rollouts call `image.DockerImageName()` to get the full image reference and use it in templates. The nix path returns the same `name:tag` format.
+
+The rollout command's concurrent build logic (semaphores, goroutines) works unchanged — nix images participate in the same pool.
+
+One difference: for nix images, `Build()` already pushes via skopeo, so the rollout command's separate `docker.Push()` call should be skipped for nix images. This requires a small check: add an `IsNix() bool` method or check `i.Nix != nil` in the rollout command.
+
+## Files to Modify
+
+1. **`image/image.go`** — Add `NixImage` struct, `Nix` field, branch logic in all methods
+2. **`nix/instantiate.go`** (new) — `Instantiate()`, `DrvHash()`
+3. **`nix/build.go`** (new) — `Build()`
+4. **`nix/skopeo.go`** (new) — `SkopeoImageExists()`, `SkopeoCopy()`
+5. **`config/load.go`** — Add validation (exactly one of `go:` / `nix:` per image)
+6. **`command/rollout/command.go`** — Skip `docker.Push()` for nix images (skopeo handles it in Build)
+7. **`command/images/build/command.go`** — May need minor adjustment for nix images (no local docker check)
+
+## Verification
+
+1. Create a test `.nix` file that uses `dockerTools.buildLayeredImage` to produce a simple image
+2. Add a nix image entry to `.monotool/config.yaml`
+3. Run `monotool images list` — should show the nix image with correct tag
+4. Run `monotool images build` — should run nix-build and show success
+5. Run `go test ./...` — all existing tests still pass
+6. Verify `nix-instantiate` + `nix-build` + `skopeo copy` are called correctly (can test with a local registry)

--- a/image/image.go
+++ b/image/image.go
@@ -9,33 +9,46 @@ import (
 
 	"github.com/draganm/gosha/gosha"
 	"github.com/draganm/monotool/docker"
+	"github.com/draganm/monotool/nix"
 )
 
 type Image struct {
-	Go          *GoImage `yaml:"go"`
-	DockerImage string   `yaml:"dockerImage"`
-	Platform    string   `yaml:"platform"`
+	Go          *GoImage  `yaml:"go"`
+	Nix         *NixImage `yaml:"nix"`
+	DockerImage string    `yaml:"dockerImage"`
+	Platform    string    `yaml:"platform"`
 }
 
 type GoImage struct {
 	Package string `yaml:"package"`
 }
 
-func (i *Image) calculateHash(projectRoot string) ([]byte, error) {
-	if i.Go == nil {
-		return nil, errors.New("no go configuration for the container found")
-	}
+type NixImage struct {
+	File string `yaml:"file"`
+}
 
-	sha, err := gosha.CalculatePackageSHA(filepath.Join(projectRoot, i.Go.Package), false, false)
-	if err != nil {
-		return nil, fmt.Errorf("could not calculate sha of the go module: %w", err)
+func (i *Image) calculateTag(ctx context.Context, projectRoot string) (string, error) {
+	switch {
+	case i.Go != nil:
+		sha, err := gosha.CalculatePackageSHA(filepath.Join(projectRoot, i.Go.Package), false, false)
+		if err != nil {
+			return "", fmt.Errorf("could not calculate sha of the go module: %w", err)
+		}
+		return fmt.Sprintf("%x", sha[:8]), nil
+	case i.Nix != nil:
+		drvPath, err := nix.Instantiate(ctx, filepath.Join(projectRoot, i.Nix.File))
+		if err != nil {
+			return "", fmt.Errorf("could not instantiate nix derivation: %w", err)
+		}
+		return nix.DrvHash(drvPath), nil
+	default:
+		return "", errors.New("no go or nix configuration for the image found")
 	}
-	return sha, nil
 }
 
 func (i *Image) IsAlreadyBuilt(ctx context.Context, projectRoot string) (bool, error) {
 
-	imageWithTag, err := i.DockerImageName(projectRoot)
+	imageWithTag, err := i.DockerImageName(ctx, projectRoot)
 	if err != nil {
 		return false, err
 	}
@@ -62,34 +75,43 @@ func (i *Image) IsAlreadyBuilt(ctx context.Context, projectRoot string) (bool, e
 
 }
 
-func (i *Image) DockerImageName(projectRoot string) (string, error) {
-	hash, err := i.calculateHash(projectRoot)
+func (i *Image) DockerImageName(ctx context.Context, projectRoot string) (string, error) {
+	tag, err := i.calculateTag(ctx, projectRoot)
 	if err != nil {
 		return "", fmt.Errorf("could not calculate hash: %w", err)
 	}
 
-	imageName := fmt.Sprintf("%s:%x", i.DockerImage, hash[:8])
-
-	return imageName, nil
+	return fmt.Sprintf("%s:%s", i.DockerImage, tag), nil
 }
 
 func (i *Image) Build(ctx context.Context, projectRoot string) error {
-
-	imageWithTag, err := i.DockerImageName(projectRoot)
+	imageWithTag, err := i.DockerImageName(ctx, projectRoot)
 	if err != nil {
 		return err
 	}
 
-	platform := i.Platform
-	if platform == "" {
-		platform = "linux/amd64"
-	}
+	switch {
+	case i.Go != nil:
+		platform := i.Platform
+		if platform == "" {
+			platform = "linux/amd64"
+		}
 
-	err = docker.BuildGoMod(ctx, path.Join(projectRoot, i.Go.Package), imageWithTag, platform)
-	if err != nil {
-		return fmt.Errorf("while building image %s: %w", imageWithTag, err)
+		err = docker.BuildGoMod(ctx, path.Join(projectRoot, i.Go.Package), imageWithTag, platform)
+		if err != nil {
+			return fmt.Errorf("while building image %s: %w", imageWithTag, err)
+		}
+	case i.Nix != nil:
+		resultPath, err := nix.Build(ctx, filepath.Join(projectRoot, i.Nix.File))
+		if err != nil {
+			return fmt.Errorf("while building nix image %s: %w", imageWithTag, err)
+		}
+
+		err = nix.DockerLoad(ctx, resultPath, imageWithTag)
+		if err != nil {
+			return fmt.Errorf("while loading nix image %s: %w", imageWithTag, err)
+		}
 	}
 
 	return nil
-
 }

--- a/nix/build.go
+++ b/nix/build.go
@@ -1,0 +1,92 @@
+package nix
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Build runs nix-build on the given nix file and returns the resolved result path
+// (the Nix store path the result symlink points to).
+func Build(ctx context.Context, nixFile string) (string, error) {
+	absPath, err := filepath.Abs(nixFile)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve nix file path: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "nix-build", absPath, "--no-out-link")
+	out := new(bytes.Buffer)
+	errOut := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = errOut
+
+	err = cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("nix-build failed (%w):\n%s", err, errOut.String())
+	}
+
+	resultPath := strings.TrimSpace(out.String())
+	if resultPath == "" {
+		return "", fmt.Errorf("nix-build returned empty output")
+	}
+
+	// Verify the result path exists
+	if _, err := os.Stat(resultPath); err != nil {
+		return "", fmt.Errorf("nix-build result path does not exist: %w", err)
+	}
+
+	return resultPath, nil
+}
+
+// DockerLoad loads a nix-built image tarball into the local Docker daemon
+// and tags it with the given image name.
+func DockerLoad(ctx context.Context, archivePath string, imageRef string) error {
+	cmd := exec.CommandContext(ctx, "docker", "load", "-i", archivePath)
+	out := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("docker load failed (%w):\n%s", err, out.String())
+	}
+
+	// docker load outputs "Loaded image: <name:tag>" or "Loaded image ID: sha256:..."
+	// We need to tag the loaded image with our desired reference.
+	loadedOutput := out.String()
+	loadedImage := parseLoadedImage(loadedOutput)
+	if loadedImage == "" {
+		return fmt.Errorf("could not parse loaded image from docker load output: %s", loadedOutput)
+	}
+
+	cmd = exec.CommandContext(ctx, "docker", "tag", loadedImage, imageRef)
+	out = new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("docker tag failed (%w):\n%s", err, out.String())
+	}
+
+	return nil
+}
+
+// parseLoadedImage extracts the image reference from docker load output.
+// Output is typically "Loaded image: name:tag" or "Loaded image ID: sha256:abc123".
+func parseLoadedImage(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if v, ok := strings.CutPrefix(line, "Loaded image: "); ok {
+			return v
+		}
+		if v, ok := strings.CutPrefix(line, "Loaded image ID: "); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/nix/instantiate.go
+++ b/nix/instantiate.go
@@ -1,0 +1,51 @@
+package nix
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Instantiate runs nix-instantiate on the given nix file and returns the derivation store path.
+func Instantiate(ctx context.Context, nixFile string) (string, error) {
+	absPath, err := filepath.Abs(nixFile)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve nix file path: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "nix-instantiate", absPath)
+	out := new(bytes.Buffer)
+	errOut := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = errOut
+
+	err = cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("nix-instantiate failed (%w):\n%s", err, errOut.String())
+	}
+
+	drvPath := strings.TrimSpace(out.String())
+	if drvPath == "" {
+		return "", fmt.Errorf("nix-instantiate returned empty output")
+	}
+
+	return drvPath, nil
+}
+
+// DrvHash extracts the first 8 characters of the hash from a Nix store path.
+// A store path looks like /nix/store/<hash>-<name>.drv
+func DrvHash(drvPath string) string {
+	base := filepath.Base(drvPath)
+	// The hash is everything before the first '-'
+	if idx := strings.IndexByte(base, '-'); idx > 0 {
+		hash := base[:idx]
+		if len(hash) > 8 {
+			return hash[:8]
+		}
+		return hash
+	}
+	return base
+}


### PR DESCRIPTION
## Add Nix-based Docker image building

### Summary

- Add support for building Docker images from Nix expressions (e.g., `dockerTools.buildLayeredImage`) as an alternative to the existing Go/Docker build pipeline
- Nix images are configured with a `nix.file` field pointing to a `.nix` file, tagged using the Nix derivation hash (via `nix-instantiate`), built with `nix-build`, and loaded into Docker via `docker load`
- Config validation ensures each image uses exactly one of `go:` or `nix:` (not both, not neither)
- Add project README with documentation and examples for both image types
