### PR TITLE
Pass platform to nix-build and nix-instantiate

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -36,7 +36,11 @@ func (i *Image) calculateTag(ctx context.Context, projectRoot string) (string, e
 		}
 		return fmt.Sprintf("%x", sha[:8]), nil
 	case i.Nix != nil:
-		drvPath, err := nix.Instantiate(ctx, filepath.Join(projectRoot, i.Nix.File))
+		platform := i.Platform
+		if platform == "" {
+			platform = "linux/amd64"
+		}
+		drvPath, err := nix.Instantiate(ctx, filepath.Join(projectRoot, i.Nix.File), platform)
 		if err != nil {
 			return "", fmt.Errorf("could not instantiate nix derivation: %w", err)
 		}
@@ -102,7 +106,11 @@ func (i *Image) Build(ctx context.Context, projectRoot string) error {
 			return fmt.Errorf("while building image %s: %w", imageWithTag, err)
 		}
 	case i.Nix != nil:
-		resultPath, err := nix.Build(ctx, filepath.Join(projectRoot, i.Nix.File))
+		platform := i.Platform
+		if platform == "" {
+			platform = "linux/amd64"
+		}
+		resultPath, err := nix.Build(ctx, filepath.Join(projectRoot, i.Nix.File), platform)
 		if err != nil {
 			return fmt.Errorf("while building nix image %s: %w", imageWithTag, err)
 		}

--- a/nix/build.go
+++ b/nix/build.go
@@ -12,13 +12,20 @@ import (
 
 // Build runs nix-build on the given nix file and returns the resolved result path
 // (the Nix store path the result symlink points to).
-func Build(ctx context.Context, nixFile string) (string, error) {
+// The platform parameter uses Docker format (e.g. "linux/amd64") and is converted
+// to a Nix system string passed as --argstr system.
+func Build(ctx context.Context, nixFile string, platform string) (string, error) {
 	absPath, err := filepath.Abs(nixFile)
 	if err != nil {
 		return "", fmt.Errorf("could not resolve nix file path: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, "nix-build", absPath, "--no-out-link")
+	nixSystem, err := dockerPlatformToNixSystem(platform)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := exec.CommandContext(ctx, "nix-build", absPath, "--no-out-link", "--argstr", "system", nixSystem)
 	out := new(bytes.Buffer)
 	errOut := new(bytes.Buffer)
 	cmd.Stdout = out
@@ -74,6 +81,23 @@ func DockerLoad(ctx context.Context, archivePath string, imageRef string) error 
 	}
 
 	return nil
+}
+
+// dockerPlatformToNixSystem converts a Docker platform string (e.g. "linux/amd64")
+// to a Nix system string (e.g. "x86_64-linux").
+func dockerPlatformToNixSystem(platform string) (string, error) {
+	switch platform {
+	case "linux/amd64":
+		return "x86_64-linux", nil
+	case "linux/arm64":
+		return "aarch64-linux", nil
+	case "linux/arm/v7":
+		return "armv7l-linux", nil
+	case "linux/386":
+		return "i686-linux", nil
+	default:
+		return "", fmt.Errorf("unsupported platform for nix build: %s", platform)
+	}
 }
 
 // parseLoadedImage extracts the image reference from docker load output.

--- a/nix/instantiate.go
+++ b/nix/instantiate.go
@@ -10,13 +10,20 @@ import (
 )
 
 // Instantiate runs nix-instantiate on the given nix file and returns the derivation store path.
-func Instantiate(ctx context.Context, nixFile string) (string, error) {
+// The platform parameter uses Docker format (e.g. "linux/amd64") and is converted
+// to a Nix system string passed as --argstr system.
+func Instantiate(ctx context.Context, nixFile string, platform string) (string, error) {
 	absPath, err := filepath.Abs(nixFile)
 	if err != nil {
 		return "", fmt.Errorf("could not resolve nix file path: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, "nix-instantiate", absPath)
+	nixSystem, err := dockerPlatformToNixSystem(platform)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := exec.CommandContext(ctx, "nix-instantiate", absPath, "--argstr", "system", nixSystem)
 	out := new(bytes.Buffer)
 	errOut := new(bytes.Buffer)
 	cmd.Stdout = out


### PR DESCRIPTION
## Summary
- Pass the configured `platform` (defaulting to `linux/amd64`) to `nix-build` and `nix-instantiate` via `--argstr system`, matching the existing Go image build behavior
- Add `dockerPlatformToNixSystem` helper to convert Docker platform strings (e.g. `linux/amd64`) to Nix system strings (e.g. `x86_64-linux`)
- Platform is passed for both image building and tag calculation (instantiate), so derivation hashes correctly reflect the target platform

## Test plan
- [ ] Verify `nix-build` receives `--argstr system x86_64-linux` when platform is unset or `linux/amd64`
- [ ] Verify `nix-build` receives `--argstr system aarch64-linux` when platform is `linux/arm64`
- [ ] Verify Nix expressions that accept a `system` argument build for the correct target

🤖 Generated with [Claude Code](https://claude.com/claude-code)