### PR TITLE
Fix nix platform targeting with --system flag

### DIFF
--- a/nix/build.go
+++ b/nix/build.go
@@ -25,7 +25,7 @@ func Build(ctx context.Context, nixFile string, platform string) (string, error)
 		return "", err
 	}
 
-	cmd := exec.CommandContext(ctx, "nix-build", absPath, "--no-out-link", "--argstr", "system", nixSystem)
+	cmd := exec.CommandContext(ctx, "nix-build", absPath, "--no-out-link", "--system", nixSystem)
 	out := new(bytes.Buffer)
 	errOut := new(bytes.Buffer)
 	cmd.Stdout = out

--- a/nix/instantiate.go
+++ b/nix/instantiate.go
@@ -23,7 +23,7 @@ func Instantiate(ctx context.Context, nixFile string, platform string) (string, 
 		return "", err
 	}
 
-	cmd := exec.CommandContext(ctx, "nix-instantiate", absPath, "--argstr", "system", nixSystem)
+	cmd := exec.CommandContext(ctx, "nix-instantiate", absPath, "--system", nixSystem)
 	out := new(bytes.Buffer)
 	errOut := new(bytes.Buffer)
 	cmd.Stdout = out


### PR DESCRIPTION
## Summary
- Use `--system` instead of `--argstr system` for `nix-build` and `nix-instantiate`
- `--argstr` only passes a string argument to the Nix expression without changing the evaluation platform, causing builds to fail on cross-platform setups (e.g. `aarch64-darwin` host trying to build `linux/amd64` images)
- `--system` correctly sets the target platform for evaluation

## Test plan
- [ ] Verify `nix-instantiate` succeeds for `linux/amd64` images on an `aarch64-darwin` host
- [ ] Verify `nix-build` produces images for the correct target platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)