### PR TITLE
Expose KVM for nix Docker builds

### DIFF
--- a/nix/build.go
+++ b/nix/build.go
@@ -74,11 +74,12 @@ func buildViaDarwinDocker(ctx context.Context, absPath string, nixSystem string)
 	// Run nix-build inside a nixos/nix container.
 	// Mount the project dir (read-only) and an output dir to copy the result.
 	buildScript := fmt.Sprintf(
-		`set -e; result=$(nix-build /project/%s --no-out-link --system %s); cp "$result" /out/result.tar.gz`,
+		`set -e; result=$(nix-build /project/%s --no-out-link --system %s --option extra-system-features kvm); cp "$result" /out/result.tar.gz`,
 		nixFileName, nixSystem,
 	)
 
 	cmd := exec.CommandContext(ctx, "docker", "run", "--rm",
+		"--device", "/dev/kvm",
 		"-v", projectDir+":/project:ro",
 		"-v", outDir+":/out",
 		"nixos/nix",


### PR DESCRIPTION
## Summary
- Pass `--device /dev/kvm` to the Docker container so KVM is available from Docker Desktop's Linux VM
- Add `--option extra-system-features kvm` to `nix-build` so Nix knows KVM is available
- Fixes: `error: Cannot build ... Reason: missing system features, Required features: {kvm}`

## Test plan
- [ ] On macOS, verify `monotool images build` for a Nix image requiring KVM (e.g. dockerTools with QEMU) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)