### PR TITLE
feat: add docker build type for arbitrary Dockerfile + context

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ images:
     dockerImage: registry.example.com/mynixservice
     nix:
       file: nix/mynixservice.nix
+  mydockerservice:
+    dockerImage: registry.example.com/mydockerservice
+    docker:
+      context: ./services/mydockerservice
+      # dockerfile: Dockerfile.prod   # optional, relative to context; defaults to "Dockerfile"
 
 rollouts:
   production:
@@ -43,7 +48,7 @@ rollouts:
 
 ## Image Types
 
-Each image must use exactly one build method: `go` or `nix`.
+Each image must use exactly one build method: `go`, `nix`, or `docker`.
 
 ### Go Images
 
@@ -102,6 +107,25 @@ pkgs.dockerTools.buildLayeredImage {
 
 The Nix expression must evaluate to a Docker image tarball (the output of `dockerTools.buildLayeredImage` or `dockerTools.buildImage`).
 
+### Docker Images
+
+Builds a Docker image from an arbitrary `Dockerfile` + context directory using `docker buildx`. Use this when your image doesn't fit the Go template or a Nix derivation — e.g., multi-language projects, images based on existing Dockerfiles, or anything with custom build steps.
+
+```yaml
+images:
+  web:
+    dockerImage: registry.example.com/web
+    docker:
+      context: ./services/web
+      # dockerfile: Dockerfile.prod   # optional, relative to the context directory
+    platform: linux/amd64             # optional, defaults to linux/amd64
+```
+
+- `context` is resolved **relative to the project root** (matching `go.package` and `nix.file`).
+- `dockerfile` is resolved **relative to the context directory**, matching Docker's own `docker build -f` convention. If omitted, `Dockerfile` inside the context is used.
+
+The image is tagged with a deterministic hash computed from the Dockerfile contents plus a sorted manifest of the context directory. `.dockerignore` is honored using the same matcher Docker/BuildKit itself uses, so the tag only changes when files Docker would actually send to the daemon change. Negation patterns (`!keep.txt`) work as expected.
+
 ## Commands
 
 ```bash
@@ -126,4 +150,5 @@ The `rollout` command builds all images concurrently, pushes them to the registr
 
 - **Go images:** Docker daemon running, `docker` CLI available
 - **Nix images:** `nix-build` and `nix-instantiate` available, Docker daemon running
+- **Docker images:** Docker daemon running, `docker buildx` available
 - **Rollouts:** `git` in PATH; `tea` CLI for Gitea PR creation

--- a/command/init/config.yaml
+++ b/command/init/config.yaml
@@ -3,3 +3,8 @@ images:
     dockerImage: <please insert docker image (without a tag) here>
     go:
       package: <please enter the directory of the go main module here>
+  # image2:
+  #   dockerImage: <please insert docker image (without a tag) here>
+  #   docker:
+  #     context: <path to docker build context, relative to project root>
+  #     # dockerfile: <optional Dockerfile path, relative to the context directory; defaults to "Dockerfile">

--- a/config/load.go
+++ b/config/load.go
@@ -37,13 +37,21 @@ func Load() (*Config, error) {
 		cfg.ProjectRoot = dir
 
 		for name, img := range cfg.Images {
-			hasGo := img.Go != nil
-			hasNix := img.Nix != nil
-			if hasGo && hasNix {
-				return nil, fmt.Errorf("image %q has both go and nix configuration, only one is allowed", name)
+			count := 0
+			if img.Go != nil {
+				count++
 			}
-			if !hasGo && !hasNix {
-				return nil, fmt.Errorf("image %q has neither go nor nix configuration, one is required", name)
+			if img.Nix != nil {
+				count++
+			}
+			if img.Docker != nil {
+				count++
+			}
+			if count > 1 {
+				return nil, fmt.Errorf("image %q has more than one of go/nix/docker configuration, exactly one is required", name)
+			}
+			if count == 0 {
+				return nil, fmt.Errorf("image %q has none of go/nix/docker configuration, exactly one is required", name)
 			}
 		}
 

--- a/docker/build.go
+++ b/docker/build.go
@@ -1,0 +1,39 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// BuildDockerfile builds a Docker image from the given context directory and
+// Dockerfile path using `docker buildx build`. The resulting image is tagged
+// with imageName and loaded into the local Docker daemon.
+func BuildDockerfile(ctx context.Context, contextDir, dockerfilePath, imageName, platform string) error {
+	if info, err := os.Stat(contextDir); err != nil {
+		return fmt.Errorf("stat context dir %s: %w", contextDir, err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("context path is not a directory: %s", contextDir)
+	}
+	if _, err := os.Stat(dockerfilePath); err != nil {
+		return fmt.Errorf("stat dockerfile %s: %w", dockerfilePath, err)
+	}
+
+	cmd := exec.CommandContext(ctx, "docker", "buildx", "build",
+		"--platform", platform,
+		"-t", imageName,
+		"-f", dockerfilePath,
+		"--progress", "plain",
+		contextDir,
+	)
+	out := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker build failed (%w):\n%s", err, out.String())
+	}
+	return nil
+}

--- a/docker/hash.go
+++ b/docker/hash.go
@@ -1,0 +1,146 @@
+package docker
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/moby/patternmatcher"
+	"github.com/moby/patternmatcher/ignorefile"
+)
+
+// HashBuildContext computes a deterministic 8-byte hex tag for a Docker build
+// context directory and its Dockerfile. Files excluded by a .dockerignore inside
+// the context are not hashed, matching Docker/BuildKit's own view of the context.
+// The .dockerignore file itself is hashed separately so that changing the rules
+// still changes the tag, and the Dockerfile is hashed explicitly so that a
+// Dockerfile living outside the context is also accounted for.
+func HashBuildContext(contextDir, dockerfilePath string) (string, error) {
+	info, err := os.Stat(contextDir)
+	if err != nil {
+		return "", fmt.Errorf("stat context dir %s: %w", contextDir, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("context path is not a directory: %s", contextDir)
+	}
+
+	h := sha256.New()
+
+	// 1. Dockerfile contents.
+	dfContent, err := os.ReadFile(dockerfilePath)
+	if err != nil {
+		return "", fmt.Errorf("read dockerfile %s: %w", dockerfilePath, err)
+	}
+	dfSum := sha256.Sum256(dfContent)
+	fmt.Fprintf(h, "dockerfile\x00%x\n", dfSum)
+
+	// 2. .dockerignore: hash contents explicitly and build a matcher.
+	var matcher *patternmatcher.PatternMatcher
+	dockerignorePath := filepath.Join(contextDir, ".dockerignore")
+	diContent, err := os.ReadFile(dockerignorePath)
+	switch {
+	case err == nil:
+		diSum := sha256.Sum256(diContent)
+		fmt.Fprintf(h, "dockerignore\x00%x\n", diSum)
+
+		f, err := os.Open(dockerignorePath)
+		if err != nil {
+			return "", fmt.Errorf("open .dockerignore: %w", err)
+		}
+		patterns, perr := ignorefile.ReadAll(f)
+		f.Close()
+		if perr != nil {
+			return "", fmt.Errorf("parse .dockerignore: %w", perr)
+		}
+		matcher, err = patternmatcher.New(patterns)
+		if err != nil {
+			return "", fmt.Errorf("build .dockerignore matcher: %w", err)
+		}
+	case os.IsNotExist(err):
+		// no .dockerignore — nothing to exclude
+	default:
+		return "", fmt.Errorf("read .dockerignore: %w", err)
+	}
+
+	// 3. Walk the context directory, collecting surviving entries.
+	type entry struct {
+		rel string
+		d   fs.DirEntry
+	}
+	var entries []entry
+
+	walkErr := filepath.WalkDir(contextDir, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if p == contextDir {
+			return nil
+		}
+		rel, err := filepath.Rel(contextDir, p)
+		if err != nil {
+			return fmt.Errorf("rel %s: %w", p, err)
+		}
+		rel = filepath.ToSlash(rel)
+
+		if matcher != nil {
+			matched, err := matcher.MatchesOrParentMatches(rel)
+			if err != nil {
+				return fmt.Errorf("match %s: %w", rel, err)
+			}
+			if matched {
+				// If the entry is a directory and there are no negation patterns
+				// that could re-include children, prune the subtree. Otherwise
+				// descend so negations can still take effect.
+				if d.IsDir() && !matcher.Exclusions() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+
+		entries = append(entries, entry{rel: rel, d: d})
+		return nil
+	})
+	if walkErr != nil {
+		return "", fmt.Errorf("walk context: %w", walkErr)
+	}
+
+	// 4. Sort by relative path (defensive — WalkDir is already lexical).
+	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+
+	// 5. Feed each entry into the running hash.
+	for _, e := range entries {
+		einfo, err := e.d.Info()
+		if err != nil {
+			return "", fmt.Errorf("stat %s: %w", e.rel, err)
+		}
+		mode := einfo.Mode()
+
+		switch {
+		case mode.IsRegular():
+			content, err := os.ReadFile(filepath.Join(contextDir, e.rel))
+			if err != nil {
+				return "", fmt.Errorf("read %s: %w", e.rel, err)
+			}
+			contentSum := sha256.Sum256(content)
+			fmt.Fprintf(h, "file\x00%s\x00%o\x00%x\n", e.rel, mode.Perm(), contentSum)
+		case mode&fs.ModeSymlink != 0:
+			target, err := os.Readlink(filepath.Join(contextDir, e.rel))
+			if err != nil {
+				return "", fmt.Errorf("readlink %s: %w", e.rel, err)
+			}
+			fmt.Fprintf(h, "link\x00%s\x00%s\n", e.rel, target)
+		case mode.IsDir():
+			// Directories contribute no entry; their children carry the signal.
+		default:
+			return "", fmt.Errorf("unsupported file type in build context: %s (mode %s)", e.rel, mode)
+		}
+	}
+
+	sum := h.Sum(nil)
+	return hex.EncodeToString(sum[:8]), nil
+}

--- a/docker/hash_test.go
+++ b/docker/hash_test.go
@@ -1,0 +1,215 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile creates a file at dir/rel with the given content, creating
+// parent directories as needed. It fails the test on any I/O error.
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdirall %s: %v", filepath.Dir(p), err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+}
+
+func mustHash(t *testing.T, contextDir, dockerfile string) string {
+	t.Helper()
+	h, err := HashBuildContext(contextDir, dockerfile)
+	if err != nil {
+		t.Fatalf("HashBuildContext(%s, %s): %v", contextDir, dockerfile, err)
+	}
+	return h
+}
+
+func TestHashBuildContext_StableAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	writeFile(t, dir, "main.go", "package main\n")
+
+	df := filepath.Join(dir, "Dockerfile")
+	h1 := mustHash(t, dir, df)
+	h2 := mustHash(t, dir, df)
+	if h1 != h2 {
+		t.Errorf("expected stable hash, got %q and %q", h1, h2)
+	}
+}
+
+func TestHashBuildContext_EightByteHex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+
+	h := mustHash(t, dir, filepath.Join(dir, "Dockerfile"))
+	if len(h) != 16 {
+		t.Errorf("expected 16-char hex (8 bytes), got %d chars: %q", len(h), h)
+	}
+	for _, c := range h {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("expected lowercase hex, got %q in %q", c, h)
+			break
+		}
+	}
+}
+
+func TestHashBuildContext_FileModificationChangesHash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	writeFile(t, dir, "main.go", "package main\n")
+
+	df := filepath.Join(dir, "Dockerfile")
+	h1 := mustHash(t, dir, df)
+
+	writeFile(t, dir, "main.go", "package main\nfunc main() {}\n")
+	h2 := mustHash(t, dir, df)
+
+	if h1 == h2 {
+		t.Errorf("expected hash to change when a context file is modified, got %q twice", h1)
+	}
+}
+
+func TestHashBuildContext_FileAdditionChangesHash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+
+	df := filepath.Join(dir, "Dockerfile")
+	h1 := mustHash(t, dir, df)
+
+	writeFile(t, dir, "new.txt", "hello\n")
+	h2 := mustHash(t, dir, df)
+
+	if h1 == h2 {
+		t.Errorf("expected hash to change when a file is added, got %q twice", h1)
+	}
+}
+
+func TestHashBuildContext_FileRemovalChangesHash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	writeFile(t, dir, "tmp.txt", "hello\n")
+
+	df := filepath.Join(dir, "Dockerfile")
+	h1 := mustHash(t, dir, df)
+
+	if err := os.Remove(filepath.Join(dir, "tmp.txt")); err != nil {
+		t.Fatalf("remove tmp.txt: %v", err)
+	}
+	h2 := mustHash(t, dir, df)
+
+	if h1 == h2 {
+		t.Errorf("expected hash to change when a file is removed, got %q twice", h1)
+	}
+}
+
+func TestHashBuildContext_DockerignoreExcludesFileFromHash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	writeFile(t, dir, "main.go", "package main\n")
+	writeFile(t, dir, ".dockerignore", "ignored.txt\n")
+	writeFile(t, dir, "ignored.txt", "original\n")
+
+	df := filepath.Join(dir, "Dockerfile")
+	h1 := mustHash(t, dir, df)
+
+	writeFile(t, dir, "ignored.txt", "changed")
+	h2 := mustHash(t, dir, df)
+
+	if h1 != h2 {
+		t.Errorf("expected hash NOT to change when ignored file changes, got %q then %q", h1, h2)
+	}
+}
+
+func TestHashBuildContext_DockerignoreContentAffectsHash(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	writeFile(t, dir, "main.go", "package main\n")
+	writeFile(t, dir, ".dockerignore", "*.txt\n")
+	writeFile(t, dir, "data.txt", "data\n")
+
+	df := filepath.Join(dir, "Dockerfile")
+	h1 := mustHash(t, dir, df)
+
+	// Change .dockerignore patterns — now data.txt is included instead of excluded.
+	writeFile(t, dir, ".dockerignore", "*.log\n")
+	h2 := mustHash(t, dir, df)
+
+	if h1 == h2 {
+		t.Errorf("expected hash to change when .dockerignore patterns change, got %q twice", h1)
+	}
+}
+
+func TestHashBuildContext_DockerignoreNegationReincludesFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile", "FROM alpine\n")
+	writeFile(t, dir, ".dockerignore", "*.txt\n!keep.txt\n")
+	writeFile(t, dir, "keep.txt", "keeper\n")
+	writeFile(t, dir, "drop.txt", "dropped\n")
+
+	df := filepath.Join(dir, "Dockerfile")
+	h1 := mustHash(t, dir, df)
+
+	// drop.txt is excluded by *.txt with no re-inclusion — changes must not affect hash.
+	writeFile(t, dir, "drop.txt", "different")
+	h2 := mustHash(t, dir, df)
+	if h1 != h2 {
+		t.Errorf("expected hash NOT to change when excluded file (drop.txt) changes, got %q then %q", h1, h2)
+	}
+
+	// keep.txt is re-included by !keep.txt — changes must affect hash.
+	writeFile(t, dir, "keep.txt", "different")
+	h3 := mustHash(t, dir, df)
+	if h1 == h3 {
+		t.Errorf("expected hash to change when re-included file (keep.txt via !) changes, got %q twice", h1)
+	}
+}
+
+func TestHashBuildContext_DockerfileOutsideContextChanges(t *testing.T) {
+	base := t.TempDir()
+	ctxDir := filepath.Join(base, "ctx")
+	if err := os.MkdirAll(ctxDir, 0o755); err != nil {
+		t.Fatalf("mkdir ctx: %v", err)
+	}
+	writeFile(t, ctxDir, "main.go", "package main\n")
+
+	dockerfilePath := filepath.Join(base, "Dockerfile.prod")
+	if err := os.WriteFile(dockerfilePath, []byte("FROM alpine\n"), 0o644); err != nil {
+		t.Fatalf("write dockerfile: %v", err)
+	}
+
+	h1 := mustHash(t, ctxDir, dockerfilePath)
+
+	if err := os.WriteFile(dockerfilePath, []byte("FROM ubuntu\n"), 0o644); err != nil {
+		t.Fatalf("rewrite dockerfile: %v", err)
+	}
+	h2 := mustHash(t, ctxDir, dockerfilePath)
+
+	if h1 == h2 {
+		t.Errorf("expected hash to change when out-of-context Dockerfile changes, got %q twice", h1)
+	}
+}
+
+func TestHashBuildContext_MissingDockerfileErrors(t *testing.T) {
+	dir := t.TempDir()
+	_, err := HashBuildContext(dir, filepath.Join(dir, "Dockerfile"))
+	if err == nil {
+		t.Error("expected error when Dockerfile is missing, got nil")
+	}
+}
+
+func TestHashBuildContext_MissingContextErrors(t *testing.T) {
+	base := t.TempDir()
+	missing := filepath.Join(base, "nope")
+	dockerfile := filepath.Join(base, "Dockerfile")
+	if err := os.WriteFile(dockerfile, []byte("FROM alpine\n"), 0o644); err != nil {
+		t.Fatalf("write dockerfile: %v", err)
+	}
+	_, err := HashBuildContext(missing, dockerfile)
+	if err == nil {
+		t.Error("expected error when context dir is missing, got nil")
+	}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
             pname = "monotool";
             version = self.shortRev or self.dirtyShortRev or "dev";
             src = ./.;
-            vendorHash = "sha256-g5J9ktcgaD0qEYr9OPCvEZT2G8TIQnjQWCafBb3ccjA=";
+            vendorHash = "sha256-BSzrcR8ogu3uLcYWCvP6LPV8jDozStrFN4X0m0LerHc=";
           };
           default = self.packages.${system}.monotool;
         };

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,10 @@ require (
 	helm.sh/helm/v3 v3.13.2
 )
 
-require github.com/docker/docker v28.1.1+incompatible
+require (
+	github.com/docker/docker v28.1.1+incompatible
+	github.com/moby/patternmatcher v0.6.1
+)
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -347,6 +347,8 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
+github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=

--- a/image/image.go
+++ b/image/image.go
@@ -15,10 +15,11 @@ import (
 )
 
 type Image struct {
-	Go          *GoImage  `yaml:"go"`
-	Nix         *NixImage `yaml:"nix"`
-	DockerImage string    `yaml:"dockerImage"`
-	Platform    string    `yaml:"platform"`
+	Go          *GoImage     `yaml:"go"`
+	Nix         *NixImage    `yaml:"nix"`
+	Docker      *DockerImage `yaml:"docker"`
+	DockerImage string       `yaml:"dockerImage"`
+	Platform    string       `yaml:"platform"`
 }
 
 type GoImage struct {
@@ -27,6 +28,28 @@ type GoImage struct {
 
 type NixImage struct {
 	File string `yaml:"file"`
+}
+
+// DockerImage builds a container image from an arbitrary Dockerfile + context.
+// Context is resolved relative to the project root. Dockerfile is resolved
+// relative to the context directory (matching `docker build -f`'s convention)
+// and defaults to "Dockerfile" if omitted.
+type DockerImage struct {
+	Context    string `yaml:"context"`
+	Dockerfile string `yaml:"dockerfile"`
+}
+
+// resolvePaths returns the absolute context directory and Dockerfile path for
+// a Docker image configuration, applying the default "Dockerfile" name when
+// no explicit dockerfile is set.
+func (d *DockerImage) resolvePaths(projectRoot string) (contextDir, dockerfilePath string) {
+	contextDir = filepath.Join(projectRoot, d.Context)
+	dockerfileRel := d.Dockerfile
+	if dockerfileRel == "" {
+		dockerfileRel = "Dockerfile"
+	}
+	dockerfilePath = filepath.Join(contextDir, dockerfileRel)
+	return contextDir, dockerfilePath
 }
 
 func (i *Image) calculateTag(ctx context.Context, projectRoot string) (string, error) {
@@ -47,8 +70,15 @@ func (i *Image) calculateTag(ctx context.Context, projectRoot string) (string, e
 			return "", fmt.Errorf("could not instantiate nix derivation: %w", err)
 		}
 		return nix.DrvHash(drvPath), nil
+	case i.Docker != nil:
+		contextDir, dockerfilePath := i.Docker.resolvePaths(projectRoot)
+		tag, err := docker.HashBuildContext(contextDir, dockerfilePath)
+		if err != nil {
+			return "", fmt.Errorf("could not hash docker build context: %w", err)
+		}
+		return tag, nil
 	default:
-		return "", errors.New("no go or nix configuration for the image found")
+		return "", errors.New("no go, nix, or docker configuration for the image found")
 	}
 }
 
@@ -125,6 +155,16 @@ func (i *Image) Build(ctx context.Context, projectRoot string) error {
 		err = nix.DockerLoad(ctx, resultPath, imageWithTag)
 		if err != nil {
 			return fmt.Errorf("while loading nix image %s: %w", imageWithTag, err)
+		}
+	case i.Docker != nil:
+		platform := i.Platform
+		if platform == "" {
+			platform = "linux/amd64"
+		}
+		contextDir, dockerfilePath := i.Docker.resolvePaths(projectRoot)
+		err = docker.BuildDockerfile(ctx, contextDir, dockerfilePath, imageWithTag, platform)
+		if err != nil {
+			return fmt.Errorf("while building docker image %s: %w", imageWithTag, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds a third image build method (`docker`) alongside the existing `go` and `nix` types, so users can point at an arbitrary context directory + optional Dockerfile for images that don't fit the Go template or a Nix derivation.
- Image tags are computed as a deterministic 8-byte hex hash over the Dockerfile contents plus a sorted manifest of the context directory, with `.dockerignore` honored via `github.com/moby/patternmatcher` (same matcher Docker/BuildKit itself uses, including `!` negations), so the tag only changes when files Docker would actually send to the daemon change.
- `dockerfile` is resolved relative to the `context` directory (matching `docker build -f`'s own convention); `context` is relative to the project root (matching `go.package` / `nix.file`).

### Config shape

```yaml
images:
  web:
    dockerImage: registry.example.com/web
    docker:
      context: ./services/web
      # dockerfile: Dockerfile.prod   # optional, relative to context; defaults to "Dockerfile"
    platform: linux/amd64             # optional, defaults to linux/amd64
```

### Changes

- New `docker/hash.go` — `HashBuildContext` walks the context, applies `.dockerignore`, and produces a stable 8-byte hex tag.
- New `docker/build.go` — `BuildDockerfile` thin wrapper around `docker buildx build`.
- New `docker/hash_test.go` — 11 unit tests (determinism, add/remove/modify, `.dockerignore` exclusion, negation, out-of-context Dockerfile, error paths). First tests in the repo.
- `image/image.go` — new `DockerImage` type and dispatch branches in `calculateTag` / `Build`.
- `config/load.go` — validation now requires exactly one of `go` / `nix` / `docker`.
- `command/init/config.yaml` — adds a commented docker example.
- `README.md` — new "Docker Images" section + updated example YAML + Requirements.
- `flake.nix` — `vendorHash` regenerated for the new `moby/patternmatcher` dependency.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` clean
- [x] `go test ./docker/...` — 11/11 tests pass
- [x] `nix build .#monotool` succeeds end-to-end with updated `vendorHash`
- [x] E2E: `monotool images list` against a scratch docker-type config resolves paths and computes a stable tag
- [x] E2E: validation rejects configs with multiple types or no type

🤖 Generated with [Claude Code](https://claude.com/claude-code)