### PR TITLE
fix(github): pass --head to gh pr create

### DIFF
--- a/rollout/github/roll_out_to_github.go
+++ b/rollout/github/roll_out_to_github.go
@@ -62,7 +62,7 @@ func (g *GitHubRollout) RollOut(ctx context.Context, message string, generate fu
 		return fmt.Errorf("could not push: %w", err)
 	}
 
-	output, err := createPR(ctx, td, fmt.Sprintf("rollout %s", commitTime), message, g.Base)
+	output, err := createPR(ctx, td, fmt.Sprintf("rollout %s", commitTime), message, g.Base, branchName)
 	if err != nil {
 		return fmt.Errorf("could not create PR: %w", err)
 	}
@@ -72,8 +72,8 @@ func (g *GitHubRollout) RollOut(ctx context.Context, message string, generate fu
 	return nil
 }
 
-func createPR(ctx context.Context, dir string, title, body, base string) (string, error) {
-	args := []string{"pr", "create", "--title", title, "--body", body}
+func createPR(ctx context.Context, dir string, title, body, base, head string) (string, error) {
+	args := []string{"pr", "create", "--title", title, "--body", body, "--head", head}
 	if base != "" {
 		args = append(args, "--base", base)
 	}


### PR DESCRIPTION
## Summary

- `git push origin <branch>` in the github rollout doesn't set the upstream tracking ref, so the subsequent `gh pr create` bails with `aborted: you must first push the current branch to a remote, or use the --head flag`
- Pass `--head <branch>` explicitly to `gh pr create` so it doesn't need to look up tracking config in the temp clone

## Repro (without the fix)

```
git clone --depth 1 <repo> /tmp/x
cd /tmp/x
git checkout -b rollout-foo
# write files
git add . && git commit -m ...
git push origin rollout-foo
gh pr create --title t --body b
# -> aborted: you must first push the current branch to a remote, or use the --head flag
```

## Test plan

- [x] Ran an end-to-end rollout from `fables-for-robots/homelab-monorepo` to `fables-for-robots/homelab-cd`; PR was opened successfully (then closed as a test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)