### PR TITLE
gitops repo coexistence: ownership markers + interactive --force

### DIFF
--- a/command/rollout/command.go
+++ b/command/rollout/command.go
@@ -35,6 +35,10 @@ func Command() *cli.Command {
 				Usage:    "describe the purpose of the rollout (included in the PR description)",
 				Required: true,
 			},
+			&cli.BoolFlag{
+				Name:  "force",
+				Usage: "overwrite files in the gitops repo that aren't owned by monotool or have been edited since the last rollout",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			cfg, err := config.Load()
@@ -186,7 +190,7 @@ func Command() *cli.Command {
 			}
 
 			fmt.Printf("rolling out to %s\n", requestedRollout)
-			err = r.RollOut(ctx, cfg.ProjectRoot, values, message, false)
+			err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"))
 			if err != nil {
 				return fmt.Errorf("roll out failed: %w", err)
 			}

--- a/command/rollout/command.go
+++ b/command/rollout/command.go
@@ -3,6 +3,7 @@ package rollout
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/signal"
 	"sort"
 	"strings"
@@ -13,12 +14,14 @@ import (
 
 	"github.com/draganm/monotool/config"
 	"github.com/draganm/monotool/docker"
+	"github.com/draganm/monotool/rollout/confirm"
 	"github.com/gosuri/uiprogress"
 	"github.com/gosuri/uiprogress/util/strutil"
 	"github.com/samber/lo"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
+	"golang.org/x/term"
 )
 
 func pointerOf[T any](v T) *T {
@@ -190,7 +193,20 @@ func Command() *cli.Command {
 			}
 
 			fmt.Printf("rolling out to %s\n", requestedRollout)
-			err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"), nil)
+
+			var conf confirm.Confirmer
+			if c.Bool("force") {
+				if !term.IsTerminal(int(os.Stdin.Fd())) {
+					return errors.New("--force requires an interactive terminal")
+				}
+				conf = confirm.TTYConfirmer(os.Stdin, os.Stderr)
+			}
+
+			err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"), conf)
+			if errors.Is(err, confirm.ErrAborted) {
+				fmt.Fprintln(os.Stderr, "rollout aborted by user")
+				return cli.Exit("", 1)
+			}
 			if err != nil {
 				return fmt.Errorf("roll out failed: %w", err)
 			}

--- a/command/rollout/command.go
+++ b/command/rollout/command.go
@@ -200,6 +200,7 @@ func Command() *cli.Command {
 					return errors.New("--force requires an interactive terminal")
 				}
 				conf = confirm.TTYConfirmer(os.Stdin, os.Stderr)
+				fmt.Fprintln(os.Stderr, "--force review: confirming each destructive action")
 			}
 
 			err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"), conf)

--- a/command/rollout/command.go
+++ b/command/rollout/command.go
@@ -190,7 +190,7 @@ func Command() *cli.Command {
 			}
 
 			fmt.Printf("rolling out to %s\n", requestedRollout)
-			err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"))
+			err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"), nil)
 			if err != nil {
 				return fmt.Errorf("roll out failed: %w", err)
 			}

--- a/command/rollout/command.go
+++ b/command/rollout/command.go
@@ -186,7 +186,7 @@ func Command() *cli.Command {
 			}
 
 			fmt.Printf("rolling out to %s\n", requestedRollout)
-			err = r.RollOut(ctx, cfg.ProjectRoot, values, message)
+			err = r.RollOut(ctx, cfg.ProjectRoot, values, message, false)
 			if err != nil {
 				return fmt.Errorf("roll out failed: %w", err)
 			}

--- a/docs/superpowers/plans/2026-05-25-gitops-coexistence.md
+++ b/docs/superpowers/plans/2026-05-25-gitops-coexistence.md
@@ -1,0 +1,2060 @@
+# GitOps Repo Coexistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `monotool rollout` share its gitops repo with other writers (humans, bots) without overwriting or pruning their files; surface conflicts loudly with an opt-in `--force` override.
+
+**Architecture:** Each file monotool writes carries a SHA-256 marker — inline `# monotool-hash:` header for YAML, sidecar `<file>.monotool` for JSON. The rollout flow reads each existing file's marker before writing, collects conflicts (unmarked or hash-mismatch), and aborts unless `--force`. Pruning walks `targetPath` and only deletes files whose markers it can verify. Git staging switches from `git add .` to explicit per-path `git add` / `git rm`.
+
+**Tech Stack:** Go 1.25, stdlib only for new code (`crypto/sha256`, `encoding/hex`, `os`, `path/filepath`, `bytes`, `strings`). Tests use stdlib `testing` with table-driven cases.
+
+**Spec:** [docs/superpowers/specs/2026-05-25-gitops-coexistence-design.md](../specs/2026-05-25-gitops-coexistence-design.md)
+
+---
+
+## File Structure
+
+**New files:**
+- `rollout/ownership/ownership.go` — marker read/write, hash computation, file-type dispatch (YAML vs JSON).
+- `rollout/ownership/ownership_test.go` — table-driven tests covering all marker behaviors.
+- `rollout/conflict/conflict.go` — `Conflict` and `Set` types, report formatting.
+- `rollout/conflict/conflict_test.go` — set behavior and report rendering tests.
+
+**Modified files:**
+- `rollout/rollout.go` — replace `generateManifests` and `removeOldManifests` with marker-aware versions; change `RollOut` signature to accept `force bool` and return `(added, removed []string, err error)` through the `generate` closure.
+- `rollout/rollout_test.go` — new file, integration-ish tests for `RollOut` against a temp dir simulating the gitops working tree.
+- `rollout/gitops/operations.go` — add `StageChanges(ctx, dir, added, removed)`, remove `AddFiles`.
+- `rollout/gitea/roll_out_to_gitea.go` — accept `force bool`, call `StageChanges` with results from `generate`, skip commit/push/PR when no changes.
+- `rollout/github/roll_out_to_github.go` — same changes as gitea.
+- `command/rollout/command.go` — add `--force` CLI flag, thread through to `r.RollOut`.
+
+**File responsibilities:**
+- `ownership` knows only about marker syntax and hashing. It does not know about templates, rollouts, or git.
+- `conflict` knows only about collecting and reporting conflicts. It does not know about files.
+- `rollout` orchestrates: it consumes `ownership` and `conflict`, decides what to write/delete, and tells the rollout backend what to stage.
+- The backends (`gitea`, `github`) own git plumbing only. They are agnostic to ownership and conflicts.
+
+---
+
+## Conventions used throughout this plan
+
+- Hash format: lowercase hex SHA-256 (64 chars).
+- YAML marker line: exactly `# monotool-hash: <hex>\n`, must be the **first line** of the file. Hash is over the bytes **after** the marker line.
+- JSON sidecar: file at `<json-path>.monotool` containing the hex hash plus a trailing newline. Hash is over the JSON file's entire body.
+- "YAML" means files with extension `.yaml` or `.yml`. "JSON" means files with extension `.json`. Other extensions are not produced by the rollout (templates already filter to these) and need no handling.
+- All new exported identifiers start with `Read*`, `Write*`, `Compute*`, `Strip*` — no abbreviations.
+
+---
+
+## Task 1: Set up `rollout/ownership` package with constants
+
+**Files:**
+- Create: `rollout/ownership/ownership.go`
+
+Skeleton that other tasks build on. No behavior yet beyond constants and the marker-prefix detector.
+
+- [ ] **Step 1: Create the package file**
+
+```go
+package ownership
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// MarkerPrefix is the prefix of the YAML marker comment. The full line is
+// MarkerPrefix + <hex sha256> + "\n".
+const MarkerPrefix = "# monotool-hash: "
+
+// SidecarExt is appended to a JSON file path to form its marker sidecar path.
+const SidecarExt = ".monotool"
+
+// isYAML reports whether path has a YAML extension.
+func isYAML(path string) bool {
+	ext := filepath.Ext(path)
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// isJSON reports whether path has a JSON extension.
+func isJSON(path string) bool {
+	return filepath.Ext(path) == ".json"
+}
+
+// hasMarkerLine reports whether body starts with the YAML marker prefix.
+func hasMarkerLine(body []byte) bool {
+	return strings.HasPrefix(string(body), MarkerPrefix)
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./rollout/ownership/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rollout/ownership/ownership.go
+git commit -m "ownership: add package skeleton with marker constants"
+```
+
+---
+
+## Task 2: Implement hash computation + marker stripping
+
+**Files:**
+- Modify: `rollout/ownership/ownership.go`
+- Create: `rollout/ownership/ownership_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to (or create) `rollout/ownership/ownership_test.go`:
+
+```go
+package ownership
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestStripMarker(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		in   string
+		want string
+	}{
+		{"yaml without marker", "x.yaml", "apiVersion: v1\n", "apiVersion: v1\n"},
+		{"yaml with marker", "x.yaml", "# monotool-hash: abc\napiVersion: v1\n", "apiVersion: v1\n"},
+		{"yml with marker", "x.yml", "# monotool-hash: abc\nkind: X\n", "kind: X\n"},
+		{"json unchanged", "x.json", `{"a":1}` + "\n", `{"a":1}` + "\n"},
+		{"yaml only marker no body", "x.yaml", "# monotool-hash: abc\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripMarker(tc.path, []byte(tc.in))
+			if string(got) != tc.want {
+				t.Fatalf("StripMarker(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeBodyHash(t *testing.T) {
+	body := []byte("apiVersion: v1\nkind: ConfigMap\n")
+	sum := sha256.Sum256(body)
+	want := hex.EncodeToString(sum[:])
+
+	// YAML with no marker: hash is over the whole input.
+	gotYAML := ComputeBodyHash("x.yaml", body)
+	if gotYAML != want {
+		t.Fatalf("YAML no-marker hash = %s, want %s", gotYAML, want)
+	}
+
+	// YAML with marker: hash is over the body after the marker.
+	gotMarked := ComputeBodyHash("x.yaml", append([]byte("# monotool-hash: deadbeef\n"), body...))
+	if gotMarked != want {
+		t.Fatalf("YAML marked hash = %s, want %s", gotMarked, want)
+	}
+
+	// JSON: hash is over the entire file body (no marker possible inline).
+	gotJSON := ComputeBodyHash("x.json", body)
+	if gotJSON != want {
+		t.Fatalf("JSON hash = %s, want %s", gotJSON, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./rollout/ownership/...`
+Expected: FAIL with "undefined: StripMarker" and "undefined: ComputeBodyHash".
+
+- [ ] **Step 3: Implement `StripMarker` and `ComputeBodyHash`**
+
+Append to `rollout/ownership/ownership.go`:
+
+```go
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// StripMarker returns the portion of body that participates in the hash.
+// For YAML files with a marker line as the first line, the marker line and its
+// trailing newline are removed. All other inputs are returned unchanged.
+func StripMarker(path string, body []byte) []byte {
+	if !isYAML(path) || !hasMarkerLine(body) {
+		return body
+	}
+	nl := bytes.IndexByte(body, '\n')
+	if nl < 0 {
+		return nil
+	}
+	return body[nl+1:]
+}
+
+// ComputeBodyHash returns the lowercase-hex SHA-256 of the hash-relevant
+// portion of body (see StripMarker).
+func ComputeBodyHash(path string, body []byte) string {
+	stripped := StripMarker(path, body)
+	sum := sha256.Sum256(stripped)
+	return hex.EncodeToString(sum[:])
+}
+```
+
+Update the existing import block to include `bytes`, `crypto/sha256`, `encoding/hex`. Combine all imports into one block.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./rollout/ownership/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rollout/ownership/ownership.go rollout/ownership/ownership_test.go
+git commit -m "ownership: add StripMarker and ComputeBodyHash"
+```
+
+---
+
+## Task 3: Implement `WriteMarked` for YAML and JSON
+
+**Files:**
+- Modify: `rollout/ownership/ownership.go`
+- Modify: `rollout/ownership/ownership_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `rollout/ownership/ownership_test.go`:
+
+```go
+import (
+	"os"
+	"path/filepath"
+)
+
+func TestWriteMarkedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deploy.yaml")
+	body := []byte("apiVersion: apps/v1\nkind: Deployment\n")
+
+	if err := WriteMarked(path, body); err != nil {
+		t.Fatalf("WriteMarked: %v", err)
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	wantHash := ComputeBodyHash(path, body)
+	wantHead := MarkerPrefix + wantHash + "\n"
+	if string(written[:len(wantHead)]) != wantHead {
+		t.Fatalf("file head = %q, want %q", written[:len(wantHead)], wantHead)
+	}
+	if string(written[len(wantHead):]) != string(body) {
+		t.Fatalf("file body after marker = %q, want %q", written[len(wantHead):], body)
+	}
+}
+
+func TestWriteMarkedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	body := []byte(`{"a":1}` + "\n")
+
+	if err := WriteMarked(path, body); err != nil {
+		t.Fatalf("WriteMarked: %v", err)
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile json: %v", err)
+	}
+	if string(written) != string(body) {
+		t.Fatalf("JSON body modified: got %q, want %q", written, body)
+	}
+
+	sidecar, err := os.ReadFile(path + SidecarExt)
+	if err != nil {
+		t.Fatalf("ReadFile sidecar: %v", err)
+	}
+	wantHash := ComputeBodyHash(path, body)
+	if string(sidecar) != wantHash+"\n" {
+		t.Fatalf("sidecar = %q, want %q", sidecar, wantHash+"\n")
+	}
+}
+
+func TestWriteMarkedCreatesDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested/dir/x.yaml")
+	if err := WriteMarked(path, []byte("a: b\n")); err != nil {
+		t.Fatalf("WriteMarked nested: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./rollout/ownership/...`
+Expected: FAIL with "undefined: WriteMarked".
+
+- [ ] **Step 3: Implement `WriteMarked`**
+
+Append to `rollout/ownership/ownership.go`:
+
+```go
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteMarked writes body to path and records monotool's ownership marker.
+// For YAML files, the marker is prepended as a comment line. For JSON files,
+// the marker is stored in a sidecar file named <path>+SidecarExt. Parent
+// directories are created as needed.
+func WriteMarked(path string, body []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+
+	hash := ComputeBodyHash(path, body)
+
+	switch {
+	case isYAML(path):
+		out := make([]byte, 0, len(MarkerPrefix)+len(hash)+1+len(body))
+		out = append(out, MarkerPrefix...)
+		out = append(out, hash...)
+		out = append(out, '\n')
+		out = append(out, body...)
+		if err := os.WriteFile(path, out, 0o666); err != nil {
+			return fmt.Errorf("write yaml %s: %w", path, err)
+		}
+	case isJSON(path):
+		if err := os.WriteFile(path, body, 0o666); err != nil {
+			return fmt.Errorf("write json %s: %w", path, err)
+		}
+		if err := os.WriteFile(path+SidecarExt, []byte(hash+"\n"), 0o666); err != nil {
+			return fmt.Errorf("write sidecar %s: %w", path+SidecarExt, err)
+		}
+	default:
+		return fmt.Errorf("WriteMarked: unsupported extension for %s", path)
+	}
+	return nil
+}
+```
+
+Merge all imports into a single block at the top of the file (`bytes`, `crypto/sha256`, `encoding/hex`, `fmt`, `os`, `path/filepath`, `strings`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./rollout/ownership/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rollout/ownership/ownership.go rollout/ownership/ownership_test.go
+git commit -m "ownership: write marked YAML and JSON files"
+```
+
+---
+
+## Task 4: Implement `ReadMarker` + ownership status helpers
+
+**Files:**
+- Modify: `rollout/ownership/ownership.go`
+- Modify: `rollout/ownership/ownership_test.go`
+
+This task adds the read side and a single status function callers will use.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `rollout/ownership/ownership_test.go`:
+
+```go
+func TestStatusOwnedAndUnmodified(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ok.yaml")
+	body := []byte("kind: X\n")
+	if err := WriteMarked(path, body); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Owned {
+		t.Fatal("expected Owned=true")
+	}
+	if !st.Matches {
+		t.Fatal("expected Matches=true")
+	}
+}
+
+func TestStatusUnmarkedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.yaml")
+	if err := os.WriteFile(path, []byte("kind: X\n"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Owned {
+		t.Fatal("expected Owned=false")
+	}
+}
+
+func TestStatusHashMismatchYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.yaml")
+	if err := WriteMarked(path, []byte("a: 1\n")); err != nil {
+		t.Fatal(err)
+	}
+	// Tamper with the body while leaving the marker line intact.
+	cur, _ := os.ReadFile(path)
+	tampered := append([]byte{}, cur...)
+	tampered = append(tampered, []byte("extra: true\n")...)
+	if err := os.WriteFile(path, tampered, 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Owned {
+		t.Fatal("expected Owned=true (marker still present)")
+	}
+	if st.Matches {
+		t.Fatal("expected Matches=false (body tampered)")
+	}
+}
+
+func TestStatusUnmarkedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.json")
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Owned {
+		t.Fatal("expected Owned=false (no sidecar)")
+	}
+}
+
+func TestStatusHashMismatchJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.json")
+	if err := WriteMarked(path, []byte(`{"a":1}`+"\n")); err != nil {
+		t.Fatal(err)
+	}
+	// Tamper with the JSON, leave sidecar alone.
+	if err := os.WriteFile(path, []byte(`{"a":2}`+"\n"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Owned {
+		t.Fatal("expected Owned=true (sidecar present)")
+	}
+	if st.Matches {
+		t.Fatal("expected Matches=false (body tampered)")
+	}
+}
+
+func TestStatusMalformedMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.yaml")
+	// Marker prefix is present but the hash is not valid hex.
+	body := []byte(MarkerPrefix + "not-a-real-hash-value\nkind: X\n")
+	if err := os.WriteFile(path, body, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Owned {
+		t.Fatal("expected Owned=true (marker prefix present)")
+	}
+	if st.Matches {
+		t.Fatal("expected Matches=false (malformed marker counts as mismatch)")
+	}
+}
+
+func TestStatusMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	st, err := Status(filepath.Join(dir, "gone.yaml"))
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.Exists {
+		t.Fatal("expected Exists=false")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./rollout/ownership/...`
+Expected: FAIL with "undefined: Status".
+
+- [ ] **Step 3: Implement `Status` and `ReadMarker`**
+
+Append to `rollout/ownership/ownership.go`:
+
+```go
+import "encoding/hex"
+
+// FileStatus describes a target path's ownership state.
+type FileStatus struct {
+	// Exists reports whether the file is present on disk.
+	Exists bool
+	// Owned reports whether a monotool marker is present (YAML header or JSON
+	// sidecar). False when Exists is false.
+	Owned bool
+	// Matches reports whether the recorded marker hash equals the current
+	// body's hash. False when Owned is false or when the marker is malformed.
+	Matches bool
+}
+
+// Status inspects path and returns its ownership status. A missing file
+// produces FileStatus{} (all false) with a nil error. I/O errors other than
+// "not exist" are returned.
+func Status(path string) (FileStatus, error) {
+	body, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return FileStatus{}, nil
+	}
+	if err != nil {
+		return FileStatus{}, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	st := FileStatus{Exists: true}
+
+	markerHash, owned, err := readMarker(path, body)
+	if err != nil {
+		return FileStatus{}, err
+	}
+	st.Owned = owned
+	if !owned {
+		return st, nil
+	}
+
+	if !isHex64(markerHash) {
+		return st, nil // owned but malformed → Matches stays false
+	}
+
+	st.Matches = ComputeBodyHash(path, body) == markerHash
+	return st, nil
+}
+
+// readMarker returns the recorded hash and whether a marker was found.
+// For YAML, the marker is the first-line comment. For JSON, the marker is the
+// sidecar file. body is the file body for YAML; for JSON it is unused.
+func readMarker(path string, body []byte) (hash string, owned bool, err error) {
+	switch {
+	case isYAML(path):
+		if !hasMarkerLine(body) {
+			return "", false, nil
+		}
+		nl := bytes.IndexByte(body, '\n')
+		if nl < 0 {
+			return "", true, nil
+		}
+		line := string(body[:nl])
+		return strings.TrimSpace(strings.TrimPrefix(line, MarkerPrefix)), true, nil
+	case isJSON(path):
+		side, err := os.ReadFile(path + SidecarExt)
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		if err != nil {
+			return "", false, fmt.Errorf("read sidecar %s: %w", path+SidecarExt, err)
+		}
+		return strings.TrimSpace(string(side)), true, nil
+	default:
+		return "", false, nil
+	}
+}
+
+// isHex64 reports whether s is exactly 64 lowercase hex characters.
+func isHex64(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	if _, err := hex.DecodeString(s); err != nil {
+		return false
+	}
+	return true
+}
+```
+
+Add `errors` to the import block.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./rollout/ownership/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rollout/ownership/ownership.go rollout/ownership/ownership_test.go
+git commit -m "ownership: add Status for marker inspection"
+```
+
+---
+
+## Task 5: Add `Remove` helper for owned files
+
+**Files:**
+- Modify: `rollout/ownership/ownership.go`
+- Modify: `rollout/ownership/ownership_test.go`
+
+A small wrapper that deletes a YAML file or a JSON file + its sidecar in one call. Used by prune.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `rollout/ownership/ownership_test.go`:
+
+```go
+func TestRemoveYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.yaml")
+	if err := WriteMarked(path, []byte("a: 1\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := Remove(path); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("expected file removed")
+	}
+}
+
+func TestRemoveJSONIncludesSidecar(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.json")
+	if err := WriteMarked(path, []byte(`{"a":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := Remove(path); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("expected JSON removed")
+	}
+	if _, err := os.Stat(path + SidecarExt); !os.IsNotExist(err) {
+		t.Fatal("expected sidecar removed")
+	}
+}
+
+func TestRemoveMissingIsNoError(t *testing.T) {
+	dir := t.TempDir()
+	if err := Remove(filepath.Join(dir, "gone.yaml")); err != nil {
+		t.Fatalf("Remove missing: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./rollout/ownership/...`
+Expected: FAIL with "undefined: Remove".
+
+- [ ] **Step 3: Implement `Remove`**
+
+Append to `rollout/ownership/ownership.go`:
+
+```go
+// Remove deletes the file at path and, for JSON files, its sidecar. Missing
+// files are not an error.
+func Remove(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", path, err)
+	}
+	if isJSON(path) {
+		if err := os.Remove(path + SidecarExt); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove sidecar %s: %w", path+SidecarExt, err)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./rollout/ownership/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rollout/ownership/ownership.go rollout/ownership/ownership_test.go
+git commit -m "ownership: add Remove helper for owned files and sidecars"
+```
+
+---
+
+## Task 6: Create `rollout/conflict` package
+
+**Files:**
+- Create: `rollout/conflict/conflict.go`
+- Create: `rollout/conflict/conflict_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rollout/conflict/conflict_test.go`:
+
+```go
+package conflict
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestEmptySet(t *testing.T) {
+	s := New()
+	if !s.Empty() {
+		t.Fatal("expected empty set")
+	}
+	if s.Err() != nil {
+		t.Fatal("expected nil Err on empty set")
+	}
+}
+
+func TestAddAndErr(t *testing.T) {
+	s := New()
+	s.Add("apps/foo/x.yaml", ReasonUnmarked)
+	if s.Empty() {
+		t.Fatal("expected non-empty set")
+	}
+	if s.Err() == nil {
+		t.Fatal("expected error on non-empty set")
+	}
+}
+
+func TestReportGroupsByReason(t *testing.T) {
+	s := New()
+	s.Add("apps/foo/a.yaml", ReasonUnmarked)
+	s.Add("apps/foo/b.json", ReasonUnmarked)
+	s.Add("apps/foo/c.yaml", ReasonHashMismatch)
+
+	buf := new(bytes.Buffer)
+	s.Report(buf)
+	out := buf.String()
+
+	if !strings.Contains(out, "unmarked") {
+		t.Errorf("want 'unmarked' header, got: %s", out)
+	}
+	if !strings.Contains(out, "hash-mismatch") {
+		t.Errorf("want 'hash-mismatch' header, got: %s", out)
+	}
+	for _, p := range []string{"a.yaml", "b.json", "c.yaml"} {
+		if !strings.Contains(out, p) {
+			t.Errorf("want %q in report, got: %s", p, out)
+		}
+	}
+}
+
+func TestReportPathsSortedWithinReason(t *testing.T) {
+	s := New()
+	s.Add("apps/z.yaml", ReasonUnmarked)
+	s.Add("apps/a.yaml", ReasonUnmarked)
+
+	buf := new(bytes.Buffer)
+	s.Report(buf)
+	out := buf.String()
+
+	aIdx := strings.Index(out, "apps/a.yaml")
+	zIdx := strings.Index(out, "apps/z.yaml")
+	if aIdx < 0 || zIdx < 0 || aIdx > zIdx {
+		t.Fatalf("expected a.yaml before z.yaml in report; got:\n%s", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./rollout/conflict/...`
+Expected: FAIL with "no Go files" or "undefined" errors.
+
+- [ ] **Step 3: Implement the package**
+
+Create `rollout/conflict/conflict.go`:
+
+```go
+package conflict
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Reason describes why a file is in conflict.
+type Reason int
+
+const (
+	// ReasonUnmarked means the file exists in targetPath but has no monotool
+	// marker — it was not last written by monotool.
+	ReasonUnmarked Reason = iota
+	// ReasonHashMismatch means the file has a marker but its current body's
+	// hash does not match the marker hash — it was edited since monotool last
+	// wrote it.
+	ReasonHashMismatch
+)
+
+func (r Reason) String() string {
+	switch r {
+	case ReasonUnmarked:
+		return "unmarked"
+	case ReasonHashMismatch:
+		return "hash-mismatch"
+	default:
+		return "unknown"
+	}
+}
+
+// Conflict is a single in-flight conflict detected during a rollout.
+type Conflict struct {
+	Path   string
+	Reason Reason
+}
+
+// Set accumulates conflicts across the rollout flow.
+type Set struct {
+	items []Conflict
+}
+
+// New returns an empty Set.
+func New() *Set { return &Set{} }
+
+// Add appends a conflict.
+func (s *Set) Add(path string, reason Reason) {
+	s.items = append(s.items, Conflict{Path: path, Reason: reason})
+}
+
+// Empty reports whether the set has zero conflicts.
+func (s *Set) Empty() bool { return len(s.items) == 0 }
+
+// ErrConflicts is the sentinel returned by Err when conflicts were collected.
+var ErrConflicts = errors.New("rollout aborted: file ownership conflicts")
+
+// Err returns ErrConflicts when the set is non-empty, otherwise nil.
+func (s *Set) Err() error {
+	if s.Empty() {
+		return nil
+	}
+	return ErrConflicts
+}
+
+// Report writes a human-readable conflict report to w, grouped by reason with
+// paths sorted within each group. Reasons appear in fixed order: unmarked,
+// then hash-mismatch.
+func (s *Set) Report(w io.Writer) {
+	byReason := map[Reason][]string{}
+	for _, c := range s.items {
+		byReason[c.Reason] = append(byReason[c.Reason], c.Path)
+	}
+
+	fmt.Fprintf(w, "rollout aborted: %d conflict(s) detected\n\n", len(s.items))
+
+	for _, r := range []Reason{ReasonUnmarked, ReasonHashMismatch} {
+		paths := byReason[r]
+		if len(paths) == 0 {
+			continue
+		}
+		sort.Strings(paths)
+		switch r {
+		case ReasonUnmarked:
+			fmt.Fprintln(w, "unmarked (not owned by monotool):")
+		case ReasonHashMismatch:
+			fmt.Fprintln(w, "hash-mismatch (edited since last rollout):")
+		}
+		for _, p := range paths {
+			fmt.Fprintf(w, "  %s\n", p)
+		}
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintln(w, "re-run with --force to overwrite, or resolve manually and commit before retrying.")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./rollout/conflict/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rollout/conflict/conflict.go rollout/conflict/conflict_test.go
+git commit -m "conflict: add Set type and Report formatting"
+```
+
+---
+
+## Task 7: Rewrite `generateManifests` to be marker-aware
+
+**Files:**
+- Modify: `rollout/rollout.go`
+- Create: `rollout/rollout_test.go`
+
+This task changes only the *write* half of the rollout. Pruning is still the old `removeOldManifests` for now; that's Task 8. We also extract `generateManifests` from its closure into a top-level function so it's testable.
+
+The closure currently has signature `generate func(dir string) error`. After this task it will be `func(dir string) (written []string, conflicts *conflict.Set, err error)`. Pruning still happens through the old closure-internal logic at this point — we'll integrate the new prune in Task 8.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `rollout/rollout_test.go`:
+
+```go
+package rollout
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/draganm/monotool/rollout/conflict"
+)
+
+// helpers
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o666); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupTemplates(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		mustWrite(t, filepath.Join(dir, name), body)
+	}
+	return dir
+}
+
+func TestGenerateManifestsFirstWrite(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "apiVersion: apps/v1\nkind: Deployment\n",
+		"data.json":   `{"a":1}` + "\n",
+	})
+	workDir := t.TempDir()
+
+	written, conflicts, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifests: %v", err)
+	}
+	if !conflicts.Empty() {
+		t.Fatalf("expected no conflicts, got %d", len(conflicts.Items()))
+	}
+
+	sort.Strings(written)
+	want := []string{
+		filepath.Join(workDir, "apps/staging/data.json"),
+		filepath.Join(workDir, "apps/staging/data.json.monotool"),
+		filepath.Join(workDir, "apps/staging/deploy.yaml"),
+	}
+	if !equalSlices(written, want) {
+		t.Fatalf("written = %v, want %v", written, want)
+	}
+}
+
+func TestGenerateManifestsRefusesUnmarked(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	mustWrite(t, filepath.Join(workDir, "apps/staging/deploy.yaml"), "kind: HumanlyEdited\n")
+
+	_, conflicts, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifests: %v", err)
+	}
+	if conflicts.Empty() {
+		t.Fatal("expected conflicts, got none")
+	}
+	got := conflicts.Items()
+	if len(got) != 1 || got[0].Reason != conflict.ReasonUnmarked {
+		t.Fatalf("expected one unmarked conflict, got %+v", got)
+	}
+}
+
+func TestGenerateManifestsForceOverwritesUnmarked(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	target := filepath.Join(workDir, "apps/staging/deploy.yaml")
+	mustWrite(t, target, "kind: HumanlyEdited\n")
+
+	written, _, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+		Force:         true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) != 1 || written[0] != target {
+		t.Fatalf("written = %v, want [%s]", written, target)
+	}
+	body, _ := os.ReadFile(target)
+	if !strings.Contains(string(body), "kind: Deployment") {
+		t.Fatalf("file was not overwritten: %s", body)
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+```
+
+Note: `conflicts.Items()` returns the slice of conflicts. We'll add it to the `conflict` package next.
+
+- [ ] **Step 2: Add `Items()` accessor to the `conflict` package**
+
+Append to `rollout/conflict/conflict.go`:
+
+```go
+// Items returns a copy of the collected conflicts.
+func (s *Set) Items() []Conflict {
+	out := make([]Conflict, len(s.items))
+	copy(out, s.items)
+	return out
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./rollout/...`
+Expected: FAIL with "undefined: GenerateManifests" / "undefined: GenerateOpts".
+
+- [ ] **Step 4: Rewrite `rollout/rollout.go` to expose `GenerateManifests`**
+
+Replace the entire contents of `rollout/rollout.go` with:
+
+```go
+package rollout
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/draganm/manifestor/interpolate"
+	"github.com/draganm/monotool/rollout/conflict"
+	"github.com/draganm/monotool/rollout/gitea"
+	"github.com/draganm/monotool/rollout/github"
+	"github.com/draganm/monotool/rollout/ownership"
+	"gopkg.in/yaml.v3"
+)
+
+type Rollout struct {
+	Gitea        *gitea.GiteaRollout   `yaml:"gitea"`
+	GitHub       *github.GitHubRollout `yaml:"github"`
+	Templates    string                `yaml:"templates"`
+	TargetPath   string                `yaml:"targetPath"`
+	PruneTargets bool                  `yaml:"pruneTargets"`
+}
+
+// GenerateOpts is the input to GenerateManifests. It is exposed (and the
+// function is exported) so tests can drive the write phase without needing a
+// git remote.
+type GenerateOpts struct {
+	TemplatesPath string
+	WorkDir       string
+	TargetPath    string
+	Values        map[string]any
+	Force         bool
+}
+
+// GenerateManifests reads templates, interpolates them, and writes the
+// resulting YAML/JSON files into WorkDir/TargetPath using ownership markers.
+// It returns the absolute paths of every file it wrote (including JSON
+// sidecars) and the set of conflicts it detected. If Force is true, conflicts
+// are recorded but writes proceed anyway.
+func GenerateManifests(_ context.Context, opts GenerateOpts) (written []string, conflicts *conflict.Set, err error) {
+	conflicts = conflict.New()
+
+	templates, err := readTemplates(opts.TemplatesPath, opts.TargetPath)
+	if err != nil {
+		return nil, conflicts, err
+	}
+
+	for relPath, raw := range templates {
+		fullPath := filepath.Join(opts.WorkDir, relPath)
+
+		body, err := renderTemplate(fullPath, raw, opts.Values)
+		if err != nil {
+			return written, conflicts, fmt.Errorf("render %s: %w", relPath, err)
+		}
+
+		st, err := ownership.Status(fullPath)
+		if err != nil {
+			return written, conflicts, fmt.Errorf("status %s: %w", fullPath, err)
+		}
+
+		if st.Exists && (!st.Owned || !st.Matches) {
+			reason := conflict.ReasonUnmarked
+			if st.Owned {
+				reason = conflict.ReasonHashMismatch
+			}
+			conflicts.Add(relPath, reason)
+			if !opts.Force {
+				continue
+			}
+		}
+
+		if err := ownership.WriteMarked(fullPath, body); err != nil {
+			return written, conflicts, err
+		}
+		written = append(written, fullPath)
+		if filepath.Ext(fullPath) == ".json" {
+			written = append(written, fullPath+ownership.SidecarExt)
+		}
+	}
+
+	return written, conflicts, nil
+}
+
+// readTemplates walks templatesPath, returning a map keyed by the target-path-
+// relative path (e.g., "apps/staging/deploy.yaml") with the raw template body.
+// Non-YAML/JSON files and directories are skipped.
+func readTemplates(templatesPath, targetPath string) (map[string][]byte, error) {
+	absRoot, err := filepath.Abs(templatesPath)
+	if err != nil {
+		return nil, fmt.Errorf("abs %s: %w", templatesPath, err)
+	}
+
+	out := map[string][]byte{}
+	err = filepath.WalkDir(absRoot, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		ext := filepath.Ext(p)
+		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+			return nil
+		}
+		rel, err := filepath.Rel(absRoot, p)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("read template %s: %w", p, err)
+		}
+		out[filepath.Join(targetPath, rel)] = data
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk templates: %w", err)
+	}
+	return out, nil
+}
+
+// renderTemplate interpolates a template body using values. JSON files are
+// copied verbatim (matching pre-existing monotool behavior). YAML files are
+// run through manifestor's interpolator and re-encoded.
+func renderTemplate(path string, raw []byte, values map[string]any) ([]byte, error) {
+	if filepath.Ext(path) == ".json" {
+		return raw, nil
+	}
+	buf := new(bytes.Buffer)
+	enc := yaml.NewEncoder(buf)
+	if err := interpolate.Interpolate(string(raw), "", values, enc); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// RollOut runs a full rollout. The old removeOldManifests + write-everything
+// logic is being replaced incrementally; the next task wires the new prune in.
+func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[string]any, message string, force bool) error {
+	if r.Gitea == nil && r.GitHub == nil {
+		return errors.New("rollout must have either a gitea or github config")
+	}
+	if r.Gitea != nil && r.GitHub != nil {
+		return errors.New("rollout cannot have both gitea and github configs")
+	}
+
+	templatesAbs, err := filepath.Abs(filepath.Join(projectRoot, r.Templates))
+	if err != nil {
+		return fmt.Errorf("could not get absolute path for the deployment templates: %w", err)
+	}
+
+	generate := func(workDir string) (added, removed []string, err error) {
+		written, conflicts, err := GenerateManifests(ctx, GenerateOpts{
+			TemplatesPath: templatesAbs,
+			WorkDir:       workDir,
+			TargetPath:    r.TargetPath,
+			Values:        values,
+			Force:         force,
+		})
+		if err != nil {
+			return written, nil, err
+		}
+		if !conflicts.Empty() {
+			conflicts.Report(os.Stderr)
+			if !force {
+				return nil, nil, conflicts.Err()
+			}
+		}
+
+		// Pruning is wired in the next task. For now: no removed paths.
+		return written, nil, nil
+	}
+
+	switch {
+	case r.Gitea != nil:
+		if err := r.Gitea.RollOut(ctx, message, generate); err != nil {
+			return fmt.Errorf("gitea deployment failed: %w", err)
+		}
+	case r.GitHub != nil:
+		if err := r.GitHub.RollOut(ctx, message, generate); err != nil {
+			return fmt.Errorf("github deployment failed: %w", err)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./rollout/...`
+Expected: PASS for `ownership`, `conflict`, and the new `rollout` tests.
+
+Note: this step changes the signature of `Rollout.RollOut` (added `force bool`) and the `generate` closure passed to backends. The `gitea`/`github` `RollOut` methods still expect `func(dir string) error`. Compilation will fail; that's Task 9's job. To keep this commit green, also do the next step.
+
+- [ ] **Step 6: Temporarily adapt gitea/github call sites**
+
+In `rollout/gitea/roll_out_to_gitea.go`, change the `RollOut` signature and `generate` call from:
+
+```go
+func (g *GiteaRollout) RollOut(ctx context.Context, message string, generate func(dir string) error) error {
+```
+
+to:
+
+```go
+func (g *GiteaRollout) RollOut(ctx context.Context, message string, generate func(dir string) (added, removed []string, err error)) error {
+```
+
+And replace the `err = generate(td)` block with:
+
+```go
+_, _, err = generate(td)
+if err != nil {
+	return fmt.Errorf("could not generate manifests: %w", err)
+}
+```
+
+Make the same edits to `rollout/github/roll_out_to_github.go`. Keep `gitops.AddFiles(ctx, td)` in place; Task 9 will replace it.
+
+In `command/rollout/command.go`, update the call site:
+
+```go
+err = r.RollOut(ctx, cfg.ProjectRoot, values, message, false)
+```
+
+(temporary `false` until Task 10 adds the flag).
+
+- [ ] **Step 7: Build and test the whole project**
+
+Run: `go build ./...`
+Expected: success.
+
+Run: `go test ./...`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add rollout/rollout.go rollout/rollout_test.go rollout/conflict/conflict.go rollout/gitea/roll_out_to_gitea.go rollout/github/roll_out_to_github.go command/rollout/command.go
+git commit -m "rollout: marker-aware GenerateManifests with conflict detection"
+```
+
+---
+
+## Task 8: Replace `removeOldManifests` with marker-aware prune
+
+**Files:**
+- Modify: `rollout/rollout.go`
+- Modify: `rollout/rollout_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `rollout/rollout_test.go`:
+
+```go
+func TestPruneRemovesStaleOwnedFile(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+
+	// Pretend last rollout wrote two files.
+	staleYAML := filepath.Join(targetDir, "stale.yaml")
+	staleJSON := filepath.Join(targetDir, "stale.json")
+	mustWriteMarked(t, staleYAML, "kind: Stale\n")
+	mustWriteMarked(t, staleJSON, `{"old":true}`+"\n")
+
+	desired := map[string]struct{}{
+		filepath.Join(targetDir, "current.yaml"): {},
+	}
+
+	removed, conflicts, err := Prune(context.Background(), PruneOpts{
+		WorkDir:     workDir,
+		TargetPath:  "apps/staging",
+		DesiredAbs:  desired,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !conflicts.Empty() {
+		t.Fatalf("expected no conflicts, got %+v", conflicts.Items())
+	}
+
+	sort.Strings(removed)
+	want := []string{
+		staleJSON,
+		staleJSON + ".monotool",
+		staleYAML,
+	}
+	if !equalSlices(removed, want) {
+		t.Fatalf("removed = %v, want %v", removed, want)
+	}
+}
+
+func TestPruneSkipsUnownedFiles(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	human := filepath.Join(targetDir, "human.yaml")
+	mustWrite(t, human, "kind: HumanFile\n")
+
+	removed, conflicts, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !conflicts.Empty() {
+		t.Fatalf("expected no conflicts, got %+v", conflicts.Items())
+	}
+	if len(removed) != 0 {
+		t.Fatalf("expected no removals, got %v", removed)
+	}
+	if _, err := os.Stat(human); err != nil {
+		t.Fatalf("human file was deleted: %v", err)
+	}
+}
+
+func TestPruneFlagsHashMismatchAsConflict(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	owned := filepath.Join(targetDir, "edited.yaml")
+	mustWriteMarked(t, owned, "kind: Original\n")
+	// Tamper.
+	cur, _ := os.ReadFile(owned)
+	if err := os.WriteFile(owned, append(cur, []byte("extra: true\n")...), 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, conflicts, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Force:      false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflicts.Empty() {
+		t.Fatal("expected a hash-mismatch conflict")
+	}
+	if len(removed) != 0 {
+		t.Fatalf("expected no removals without --force, got %v", removed)
+	}
+
+	// With --force, the file is left alone but the conflict is still reported.
+	removedF, conflictsF, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Force:      true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflictsF.Empty() {
+		t.Fatal("expected conflict to still be reported under --force")
+	}
+	if len(removedF) != 0 {
+		t.Fatalf("expected no removals (file is edited), got %v", removedF)
+	}
+}
+
+func TestPruneRemovesOrphanSidecar(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	sidecar := filepath.Join(targetDir, "ghost.json.monotool")
+	mustWrite(t, sidecar, "deadbeef\n")
+
+	removed, conflicts, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !conflicts.Empty() {
+		t.Fatalf("orphan sidecar should not produce a conflict; got %+v", conflicts.Items())
+	}
+	if len(removed) != 1 || removed[0] != sidecar {
+		t.Fatalf("expected orphan sidecar removed, got %v", removed)
+	}
+}
+
+func TestPruneRemovesEmptyDirectories(t *testing.T) {
+	workDir := t.TempDir()
+	emptyAfter := filepath.Join(workDir, "apps/staging/leftovers")
+	stale := filepath.Join(emptyAfter, "x.yaml")
+	mustWriteMarked(t, stale, "kind: Stale\n")
+
+	if _, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(emptyAfter); !os.IsNotExist(err) {
+		t.Fatalf("expected empty dir removed, got err=%v", err)
+	}
+}
+
+func mustWriteMarked(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownership.WriteMarked(path, []byte(body)); err != nil {
+		t.Fatal(err)
+	}
+}
+```
+
+Add to the imports of `rollout_test.go`:
+
+```go
+"github.com/draganm/monotool/rollout/ownership"
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `go test ./rollout/...`
+Expected: FAIL with "undefined: Prune" / "undefined: PruneOpts".
+
+- [ ] **Step 3: Implement `Prune`**
+
+Append to `rollout/rollout.go` (and remove the placeholder `_ = workDir` line + the comment in the closure — that wiring is now real):
+
+```go
+// PruneOpts drives Prune. DesiredAbs is the set of absolute paths Prune must
+// leave alone (typically: every path GenerateManifests wrote, including
+// sidecars).
+type PruneOpts struct {
+	WorkDir    string
+	TargetPath string
+	DesiredAbs map[string]struct{}
+	Force      bool
+}
+
+// Prune walks WorkDir/TargetPath and deletes monotool-owned files that are no
+// longer in DesiredAbs, returning the absolute paths it removed and any
+// conflicts it detected. Unowned files (no marker) are left alone. Owned files
+// whose body hash no longer matches their marker generate a hash-mismatch
+// conflict; without Force they are not deleted, with Force they are reported
+// but still not deleted (we never delete a file a human edited).
+func Prune(_ context.Context, opts PruneOpts) (removed []string, conflicts *conflict.Set, err error) {
+	conflicts = conflict.New()
+	root := filepath.Join(opts.WorkDir, opts.TargetPath)
+
+	if _, statErr := os.Stat(root); errors.Is(statErr, os.ErrNotExist) {
+		return nil, conflicts, nil
+	}
+
+	type owned struct {
+		path string
+		rel  string
+	}
+	var ownedFiles []owned
+	var orphanSidecars []string
+
+	err = filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		// Orphan sidecar (JSON sidecar whose JSON doesn't exist) → cruft.
+		if filepath.Ext(p) == ownership.SidecarExt {
+			jsonPath := p[:len(p)-len(ownership.SidecarExt)]
+			if _, err := os.Stat(jsonPath); errors.Is(err, os.ErrNotExist) {
+				orphanSidecars = append(orphanSidecars, p)
+			}
+			return nil
+		}
+
+		// Sidecars are handled implicitly by ownership.Remove when we delete
+		// their JSONs; don't visit them as primary files.
+		st, err := ownership.Status(p)
+		if err != nil {
+			return err
+		}
+		if !st.Owned {
+			return nil
+		}
+		rel, err := filepath.Rel(opts.WorkDir, p)
+		if err != nil {
+			return err
+		}
+		ownedFiles = append(ownedFiles, owned{path: p, rel: rel})
+		return nil
+	})
+	if err != nil {
+		return nil, conflicts, fmt.Errorf("walk %s: %w", root, err)
+	}
+
+	for _, o := range ownedFiles {
+		if _, keep := opts.DesiredAbs[o.path]; keep {
+			continue
+		}
+
+		st, err := ownership.Status(o.path)
+		if err != nil {
+			return removed, conflicts, err
+		}
+		if !st.Matches {
+			conflicts.Add(o.rel, conflict.ReasonHashMismatch)
+			continue // never delete a file the human edited
+		}
+		if err := ownership.Remove(o.path); err != nil {
+			return removed, conflicts, err
+		}
+		removed = append(removed, o.path)
+		if filepath.Ext(o.path) == ".json" {
+			removed = append(removed, o.path+ownership.SidecarExt)
+		}
+	}
+
+	for _, p := range orphanSidecars {
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return removed, conflicts, err
+		}
+		removed = append(removed, p)
+	}
+
+	if err := removeEmptyDirs(root); err != nil {
+		return removed, conflicts, err
+	}
+	return removed, conflicts, nil
+}
+
+// removeEmptyDirs walks root bottom-up and removes any directory left empty.
+// root itself is not removed.
+func removeEmptyDirs(root string) error {
+	var dirs []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			dirs = append(dirs, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	// Descend deepest-first.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		if dirs[i] == root {
+			continue
+		}
+		entries, err := os.ReadDir(dirs[i])
+		if err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			if err := os.Remove(dirs[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Wire Prune into the rollout closure**
+
+Replace the `generate` closure in `Rollout.RollOut` with:
+
+```go
+generate := func(workDir string) (added, removed []string, err error) {
+	written, writeConflicts, err := GenerateManifests(ctx, GenerateOpts{
+		TemplatesPath: templatesAbs,
+		WorkDir:       workDir,
+		TargetPath:    r.TargetPath,
+		Values:        values,
+		Force:         force,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var pruneConflicts *conflict.Set
+	if r.PruneTargets {
+		desired := make(map[string]struct{}, len(written))
+		for _, p := range written {
+			desired[p] = struct{}{}
+		}
+		var pruned []string
+		pruned, pruneConflicts, err = Prune(ctx, PruneOpts{
+			WorkDir:    workDir,
+			TargetPath: r.TargetPath,
+			DesiredAbs: desired,
+			Force:      force,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		removed = pruned
+	} else {
+		pruneConflicts = conflict.New()
+	}
+
+	all := mergeConflicts(writeConflicts, pruneConflicts)
+	if !all.Empty() {
+		all.Report(os.Stderr)
+		if !force {
+			return nil, nil, all.Err()
+		}
+	}
+
+	return written, removed, nil
+}
+```
+
+And add a helper at the bottom of `rollout.go`:
+
+```go
+func mergeConflicts(a, b *conflict.Set) *conflict.Set {
+	out := conflict.New()
+	for _, c := range a.Items() {
+		out.Add(c.Path, c.Reason)
+	}
+	for _, c := range b.Items() {
+		out.Add(c.Path, c.Reason)
+	}
+	return out
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./rollout/...`
+Expected: PASS.
+
+- [ ] **Step 6: Build the whole project**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rollout/rollout.go rollout/rollout_test.go
+git commit -m "rollout: marker-aware Prune replacing removeOldManifests"
+```
+
+---
+
+## Task 9: Add `StageChanges` to gitops, remove `AddFiles`
+
+**Files:**
+- Modify: `rollout/gitops/operations.go`
+
+- [ ] **Step 1: Add `StageChanges`**
+
+Append to `rollout/gitops/operations.go`:
+
+```go
+// StageChanges runs `git add` for every added path and `git rm` for every
+// removed path. Paths must be relative to dir or absolute paths inside it. No
+// other paths are staged.
+func StageChanges(ctx context.Context, dir string, added, removed []string) error {
+	if len(added) > 0 {
+		args := append([]string{"add", "--"}, added...)
+		cmd := exec.CommandContext(ctx, "git", args...)
+		out := new(bytes.Buffer)
+		cmd.Stdout = out
+		cmd.Stderr = out
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("git add failed: %w\n%s", err, out.String())
+		}
+	}
+	if len(removed) > 0 {
+		args := append([]string{"rm", "--quiet", "--"}, removed...)
+		cmd := exec.CommandContext(ctx, "git", args...)
+		out := new(bytes.Buffer)
+		cmd.Stdout = out
+		cmd.Stderr = out
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("git rm failed: %w\n%s", err, out.String())
+		}
+	}
+	return nil
+}
+
+// HasStagedChanges reports whether any changes are staged in dir.
+func HasStagedChanges(ctx context.Context, dir string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--name-only")
+	out := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("git diff --cached failed: %w\n%s", err, out.String())
+	}
+	return out.Len() > 0, nil
+}
+```
+
+- [ ] **Step 2: Remove `AddFiles`**
+
+Delete the `AddFiles` function from `rollout/gitops/operations.go`.
+
+- [ ] **Step 3: Verify nothing else references `AddFiles`**
+
+Run: `grep -rn "gitops.AddFiles" .`
+Expected: no output (or matches only inside `roll_out_to_*.go`, which Task 10 will fix).
+
+- [ ] **Step 4: Commit**
+
+(The gitea/github files won't compile yet — that's the next task. To avoid a broken HEAD, stage but wait to commit until Task 10 Step 5.)
+
+---
+
+## Task 10: Wire `StageChanges` into gitea + github backends
+
+**Files:**
+- Modify: `rollout/gitea/roll_out_to_gitea.go`
+- Modify: `rollout/github/roll_out_to_github.go`
+
+- [ ] **Step 1: Update gitea**
+
+Replace the `RollOut` method in `rollout/gitea/roll_out_to_gitea.go`:
+
+```go
+func (g *GiteaRollout) RollOut(ctx context.Context, message string, generate func(dir string) (added, removed []string, err error)) error {
+	td, err := os.MkdirTemp("", "")
+	if err != nil {
+		return fmt.Errorf("could not create a temp dir: %w", err)
+	}
+	defer os.RemoveAll(td)
+
+	if err := gitops.CloneRepo(ctx, g.RepoURL, td); err != nil {
+		return err
+	}
+
+	commitTime := time.Now().Format("2006-01-02-15-04-05")
+	branchName := fmt.Sprintf("rollout-%s", commitTime)
+	if err := gitops.CreateBranch(ctx, td, branchName); err != nil {
+		return err
+	}
+
+	added, removed, err := generate(td)
+	if err != nil {
+		return fmt.Errorf("could not generate manifests: %w", err)
+	}
+
+	if err := gitops.StageChanges(ctx, td, added, removed); err != nil {
+		return fmt.Errorf("could not stage changes: %w", err)
+	}
+
+	hasChanges, err := gitops.HasStagedChanges(ctx, td)
+	if err != nil {
+		return err
+	}
+	if !hasChanges {
+		fmt.Println("no changes to roll out")
+		return nil
+	}
+
+	commitMessage := fmt.Sprintf("rollout %s\n\n%s", commitTime, message)
+	if err := gitops.CreateCommit(ctx, td, commitMessage); err != nil {
+		return fmt.Errorf("could not create commit: %w", err)
+	}
+	if err := gitops.PushToOrigin(ctx, td, branchName); err != nil {
+		return fmt.Errorf("could not push: %w", err)
+	}
+
+	output, err := createPR(ctx, td, fmt.Sprintf("rollout %s", commitTime), message)
+	if err != nil {
+		return fmt.Errorf("could not create PR: %w", err)
+	}
+	fmt.Println(output)
+	return nil
+}
+```
+
+- [ ] **Step 2: Update github**
+
+Apply the same shape of change to `rollout/github/roll_out_to_github.go`. The only differences from gitea are the `Base` field and the `createPR` call signature:
+
+```go
+func (g *GitHubRollout) RollOut(ctx context.Context, message string, generate func(dir string) (added, removed []string, err error)) error {
+	td, err := os.MkdirTemp("", "")
+	if err != nil {
+		return fmt.Errorf("could not create a temp dir: %w", err)
+	}
+	defer os.RemoveAll(td)
+
+	if err := gitops.CloneRepo(ctx, g.RepoURL, td); err != nil {
+		return err
+	}
+
+	commitTime := time.Now().Format("2006-01-02-15-04-05")
+	branchName := fmt.Sprintf("rollout-%s", commitTime)
+	if err := gitops.CreateBranch(ctx, td, branchName); err != nil {
+		return err
+	}
+
+	added, removed, err := generate(td)
+	if err != nil {
+		return fmt.Errorf("could not generate manifests: %w", err)
+	}
+
+	if err := gitops.StageChanges(ctx, td, added, removed); err != nil {
+		return fmt.Errorf("could not stage changes: %w", err)
+	}
+
+	hasChanges, err := gitops.HasStagedChanges(ctx, td)
+	if err != nil {
+		return err
+	}
+	if !hasChanges {
+		fmt.Println("no changes to roll out")
+		return nil
+	}
+
+	commitMessage := fmt.Sprintf("rollout %s\n\n%s", commitTime, message)
+	if err := gitops.CreateCommit(ctx, td, commitMessage); err != nil {
+		return fmt.Errorf("could not create commit: %w", err)
+	}
+	if err := gitops.PushToOrigin(ctx, td, branchName); err != nil {
+		return fmt.Errorf("could not push: %w", err)
+	}
+
+	output, err := createPR(ctx, td, fmt.Sprintf("rollout %s", commitTime), message, g.Base, branchName)
+	if err != nil {
+		return fmt.Errorf("could not create PR: %w", err)
+	}
+	fmt.Println(output)
+	return nil
+}
+```
+
+- [ ] **Step 3: Build the whole project**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `go test ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit Tasks 9 and 10 together**
+
+```bash
+git add rollout/gitops/operations.go rollout/gitea/roll_out_to_gitea.go rollout/github/roll_out_to_github.go
+git commit -m "gitops: surgical staging via StageChanges (replaces git add .)"
+```
+
+---
+
+## Task 11: Expose `--force` on the CLI
+
+**Files:**
+- Modify: `command/rollout/command.go`
+
+- [ ] **Step 1: Add the flag**
+
+In `command/rollout/command.go`, extend the `Flags` slice on the returned `cli.Command`:
+
+```go
+Flags: []cli.Flag{
+	&cli.StringFlag{
+		Name:     "message",
+		Aliases:  []string{"m"},
+		Usage:    "describe the purpose of the rollout (included in the PR description)",
+		Required: true,
+	},
+	&cli.BoolFlag{
+		Name:  "force",
+		Usage: "overwrite files in the gitops repo that aren't owned by monotool or have been edited since the last rollout",
+	},
+},
+```
+
+- [ ] **Step 2: Thread the flag into the rollout call**
+
+Replace the existing call to `r.RollOut` with:
+
+```go
+err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"))
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./...`
+Run: `go test ./...`
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add command/rollout/command.go
+git commit -m "rollout: add --force CLI flag"
+```
+
+---
+
+## Task 12: Manual smoke test against a local git repo
+
+This task is human-driven verification; there is no commit at the end. Skip if you've already exercised the flow against a real gitops repo.
+
+- [ ] **Step 1: Build the binary**
+
+Run: `go build -o /tmp/monotool-coexist ./`
+Expected: binary at `/tmp/monotool-coexist`.
+
+- [ ] **Step 2: Set up a throwaway local "remote"**
+
+```bash
+mkdir -p /tmp/coexist-test
+cd /tmp/coexist-test
+git init --bare remote.git
+git clone remote.git working
+cd working
+mkdir -p apps/staging
+echo "initial: true" > apps/staging/handwritten.yaml
+git add . && git commit -m "initial human file"
+git push
+```
+
+- [ ] **Step 3: Run a rollout pointing at the remote**
+
+Configure a minimal `.monotool/config.yaml` in a project of your choice with a rollout whose `gitea.repoUrl` (or `github.repoUrl`) is `/tmp/coexist-test/remote.git` and `pruneTargets: true`. Run `/tmp/monotool-coexist rollout <name> -m "smoke test"`.
+
+Expected: rollout completes; `handwritten.yaml` remains untouched in the gitops repo after the merge.
+
+- [ ] **Step 4: Tamper with a generated file and re-run without `--force`**
+
+Edit one of the rolled-out YAMLs in the gitops repo (e.g., bump a replica count), commit and push. Re-run the rollout without `--force`. Expected: aborts with a `hash-mismatch` conflict listing your edit.
+
+- [ ] **Step 5: Re-run with `--force`**
+
+Re-run with `--force`. Expected: warning printed, edit overwritten, fresh marker.
+
+- [ ] **Step 6: Clean up the test binary**
+
+```bash
+rm /tmp/monotool-coexist
+rm -rf /tmp/coexist-test
+```
+
+---
+
+## Summary of `--force` semantics
+
+| Situation                         | Default behavior             | With `--force`                              |
+|-----------------------------------|------------------------------|---------------------------------------------|
+| Target path has unmarked file     | abort, list as `unmarked`    | warn + overwrite                            |
+| Target file modified since marker | abort, list as `hash-mismatch` | warn + overwrite (writes a fresh marker)   |
+| Prune sees modified owned file    | abort, list as `hash-mismatch` | warn + **leave the file in place** (no delete) |
+| Prune sees stale owned file       | delete                       | delete                                       |
+| Prune sees unowned file           | leave alone                  | leave alone                                  |
+
+The "leave in place" rule for prune-time hash mismatches is deliberate: `--force` lets you overwrite a file you intend to regenerate, but it never silently deletes a file a human has edited.

--- a/docs/superpowers/plans/2026-05-26-force-interactive-confirm.md
+++ b/docs/superpowers/plans/2026-05-26-force-interactive-confirm.md
@@ -1,0 +1,947 @@
+# Interactive `--force` Confirmation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Under `--force`, prompt the operator y/n/abort for every destructive action (overwrites, deletions, orphan-sidecar removals), and require an interactive terminal when `--force` is set.
+
+**Architecture:** A new `rollout/confirm` package defines a `Confirmer` callback (`func(action, path string) (bool, error)`) and a stdin-backed `TTYConfirmer`. `GenerateOpts` and `PruneOpts` gain a `Confirm` field; both invoke it immediately before each destructive action. The closure in `Rollout.RollOut` and the CLI command thread a TTY-backed Confirmer through when `--force` is set; non-TTY `--force` errors out. A sentinel `ErrAborted` is returned when the user picks the abort option, and the CLI prints a friendly message instead of the wrapped error chain.
+
+**Tech Stack:** Go 1.25, stdlib (`bufio`, `errors`, `io`, `strings`) plus `golang.org/x/term` for the TTY check.
+
+**Spec:** [docs/superpowers/specs/2026-05-26-force-interactive-confirm-design.md](../specs/2026-05-26-force-interactive-confirm-design.md)
+
+---
+
+## File Structure
+
+**New files:**
+- `rollout/confirm/confirm.go` — `Confirmer` type, `ErrAborted` sentinel, `TTYConfirmer` constructor. Owns the prompt format and all stdin parsing.
+- `rollout/confirm/confirm_test.go` — table-driven tests for `TTYConfirmer` against a `strings.Reader` / `bytes.Buffer`.
+
+**Modified files:**
+- `rollout/rollout.go`:
+  - `GenerateOpts` gains `Confirm confirm.Confirmer`.
+  - `GenerateManifests` calls `Confirm` before each overwrite-on-conflict write.
+  - `PruneOpts` gains `Confirm confirm.Confirmer`.
+  - `Prune` calls `Confirm` before each stale-owned deletion and before each orphan-sidecar removal.
+  - `Rollout.RollOut` signature gains a `confirm confirm.Confirmer` parameter and threads it into both opts structs.
+  - The closure suppresses `Warn` output when `confirm != nil` (each prompt is already an explicit ack).
+- `rollout/rollout_test.go` — adds Confirm-related test cases for both `GenerateManifests` and `Prune`.
+- `command/rollout/command.go`:
+  - When `--force` is set, check `term.IsTerminal(int(os.Stdin.Fd()))`. Non-TTY → return an error.
+  - Construct a `confirm.TTYConfirmer(os.Stdin, os.Stderr)` and pass to `RollOut`.
+  - Catch `confirm.ErrAborted` (via `errors.Is`) and surface as `"rollout aborted by user"` rather than the wrapped chain.
+- `go.mod`, `go.sum` — `golang.org/x/term` upgraded from indirect to direct.
+
+**File responsibilities:**
+- `rollout/confirm` knows only about the prompt UI. It does not know about manifests, rollouts, or files. It exports a `Confirmer` and one implementation.
+- `rollout` orchestrates: it constructs the Confirmer's inputs (action label, relative path), invokes the callback, and acts on the result.
+- The CLI command owns TTY detection and the friendly error message for `ErrAborted`.
+
+---
+
+## Conventions
+
+- **Action labels** (passed as the `action` argument to `Confirmer`):
+  - `"overwrite unmarked"` — GenerateManifests about to write over an unowned file.
+  - `"overwrite edited"` — GenerateManifests about to write over a hash-mismatched owned file.
+  - `"delete stale"` — Prune about to delete a stale owned file.
+  - `"remove orphan sidecar"` — Prune about to remove a `.monotool` whose JSON sibling is gone.
+- **Path argument** is gitops-repo-relative (the same form as conflict reports), not absolute.
+- **`nil` Confirmer** means "no prompting, proceed unconditionally" — preserves the pre-prompt behavior for tests and for the legacy `--force` path if a future `--yes` flag is added.
+
+---
+
+## Task 1: Create `rollout/confirm` package skeleton
+
+**Files:**
+- Create: `rollout/confirm/confirm.go`
+
+- [ ] **Step 1: Create the package file**
+
+```go
+package confirm
+
+import (
+	"errors"
+)
+
+// Confirmer asks the user whether to perform a destructive action.
+// Returns proceed=true to perform the action, proceed=false to skip just
+// this one, or a non-nil error to abort the rollout entirely. A nil
+// Confirmer means "no prompting, proceed unconditionally".
+type Confirmer func(action, path string) (proceed bool, err error)
+
+// ErrAborted is returned by a Confirmer when the user picks the abort
+// option. Callers should check via errors.Is and render a friendly message
+// rather than a wrapped error chain.
+var ErrAborted = errors.New("rollout aborted by user")
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./rollout/confirm/...`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rollout/confirm/confirm.go
+git commit -m "confirm: add Confirmer type and ErrAborted sentinel"
+```
+
+---
+
+## Task 2: Implement `TTYConfirmer` with tests
+
+**Files:**
+- Modify: `rollout/confirm/confirm.go`
+- Create: `rollout/confirm/confirm_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `rollout/confirm/confirm_test.go`:
+
+```go
+package confirm
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTTYConfirmerYes(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("y\n"), out)
+	proceed, err := c("delete stale", "apps/foo/x.yaml")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !proceed {
+		t.Fatal("proceed = false, want true")
+	}
+}
+
+func TestTTYConfirmerNo(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("n\n"), out)
+	proceed, err := c("delete stale", "apps/foo/x.yaml")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if proceed {
+		t.Fatal("proceed = true, want false")
+	}
+}
+
+func TestTTYConfirmerAbort(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("a\n"), out)
+	proceed, err := c("delete stale", "apps/foo/x.yaml")
+	if !errors.Is(err, ErrAborted) {
+		t.Fatalf("err = %v, want ErrAborted", err)
+	}
+	if proceed {
+		t.Fatal("proceed = true, want false")
+	}
+}
+
+func TestTTYConfirmerRepromptsOnGarbage(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("\nxyz\ny\n"), out)
+	proceed, err := c("overwrite edited", "apps/foo/x.yaml")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !proceed {
+		t.Fatal("proceed = false, want true")
+	}
+	prompts := strings.Count(out.String(), "[y/n/a]")
+	if prompts < 3 {
+		t.Fatalf("expected at least 3 prompts, got %d, output:\n%s", prompts, out.String())
+	}
+}
+
+func TestTTYConfirmerEOFAborts(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader(""), out)
+	proceed, err := c("delete stale", "apps/foo/x.yaml")
+	if !errors.Is(err, ErrAborted) {
+		t.Fatalf("err = %v, want ErrAborted", err)
+	}
+	if proceed {
+		t.Fatal("proceed = true, want false")
+	}
+}
+
+func TestTTYConfirmerPromptText(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("y\n"), out)
+	_, _ = c("overwrite edited", "apps/staging/deploy.yaml")
+	got := out.String()
+	if !strings.Contains(got, "overwrite edited") {
+		t.Errorf("prompt missing action label: %q", got)
+	}
+	if !strings.Contains(got, "apps/staging/deploy.yaml") {
+		t.Errorf("prompt missing path: %q", got)
+	}
+	if !strings.Contains(got, "[y/n/a]") {
+		t.Errorf("prompt missing choices: %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `go test ./rollout/confirm/...`
+Expected: FAIL with "undefined: TTYConfirmer".
+
+- [ ] **Step 3: Implement `TTYConfirmer`**
+
+Append to `rollout/confirm/confirm.go`:
+
+```go
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// TTYConfirmer returns a Confirmer that prompts on out and reads decisions
+// from in line-by-line. The first non-whitespace character of each input
+// line is lowercased and mapped: 'y' = proceed, 'n' = skip, 'a' = abort.
+// Anything else reprints the prompt. EOF on in aborts.
+func TTYConfirmer(in io.Reader, out io.Writer) Confirmer {
+	br := bufio.NewReader(in)
+	return func(action, path string) (bool, error) {
+		for {
+			fmt.Fprintf(out, "%s %s? [y/n/a] ", action, path)
+			line, err := br.ReadString('\n')
+			if err == io.EOF && line == "" {
+				return false, ErrAborted
+			}
+			if err != nil && err != io.EOF {
+				return false, fmt.Errorf("read confirmation: %w", err)
+			}
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			switch strings.ToLower(trimmed)[0] {
+			case 'y':
+				return true, nil
+			case 'n':
+				return false, nil
+			case 'a':
+				return false, ErrAborted
+			}
+			// otherwise, loop and reprompt
+		}
+	}
+}
+```
+
+Merge the import block at the top of the file into a single block. Final imports: `bufio`, `errors`, `fmt`, `io`, `strings`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./rollout/confirm/...`
+Expected: PASS for all six tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rollout/confirm/confirm.go rollout/confirm/confirm_test.go
+git commit -m "confirm: add TTYConfirmer for y/n/a prompts"
+```
+
+---
+
+## Task 3: Add `Confirm` to `GenerateOpts` and wire it into `GenerateManifests`
+
+**Files:**
+- Modify: `rollout/rollout.go`
+- Modify: `rollout/rollout_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `rollout/rollout_test.go`:
+
+```go
+func TestGenerateManifestsConfirmYes(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	target := filepath.Join(workDir, "apps/staging/deploy.yaml")
+	mustWrite(t, target, "kind: HumanlyEdited\n")
+
+	var calls []string
+	conf := func(action, path string) (bool, error) {
+		calls = append(calls, action+":"+path)
+		return true, nil
+	}
+
+	written, _, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+		Force:         true,
+		Confirm:       conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 || calls[0] != "overwrite unmarked:apps/staging/deploy.yaml" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if len(written) != 1 || written[0] != target {
+		t.Fatalf("written = %v, want [%s]", written, target)
+	}
+	body, _ := os.ReadFile(target)
+	if !strings.Contains(string(body), "kind: Deployment") {
+		t.Fatalf("file not overwritten: %s", body)
+	}
+}
+
+func TestGenerateManifestsConfirmNo(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	target := filepath.Join(workDir, "apps/staging/deploy.yaml")
+	mustWrite(t, target, "kind: HumanlyEdited\n")
+
+	conf := func(action, path string) (bool, error) {
+		return false, nil
+	}
+
+	written, _, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+		Force:         true,
+		Confirm:       conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) != 0 {
+		t.Fatalf("written = %v, want empty", written)
+	}
+	body, _ := os.ReadFile(target)
+	if string(body) != "kind: HumanlyEdited\n" {
+		t.Fatalf("file was modified, body = %q", body)
+	}
+}
+
+func TestGenerateManifestsConfirmAbort(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	mustWrite(t, filepath.Join(workDir, "apps/staging/deploy.yaml"), "kind: HumanlyEdited\n")
+
+	conf := func(action, path string) (bool, error) {
+		return false, confirm.ErrAborted
+	}
+
+	_, _, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+		Force:         true,
+		Confirm:       conf,
+	})
+	if !errors.Is(err, confirm.ErrAborted) {
+		t.Fatalf("err = %v, want ErrAborted", err)
+	}
+}
+```
+
+Add to the imports of `rollout_test.go`:
+
+```go
+"errors"
+"github.com/draganm/monotool/rollout/confirm"
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `go test ./rollout/...`
+Expected: FAIL with "unknown field Confirm in GenerateOpts" and similar.
+
+- [ ] **Step 3: Add `Confirm` to `GenerateOpts` and wire it into `GenerateManifests`**
+
+In `rollout/rollout.go`:
+
+(a) Add the confirm import to the import block:
+
+```go
+"github.com/draganm/monotool/rollout/confirm"
+```
+
+(b) Extend `GenerateOpts`:
+
+```go
+// GenerateOpts is the input to GenerateManifests. It is exposed (and the
+// function is exported) so tests can drive the write phase without needing a
+// git remote.
+type GenerateOpts struct {
+	TemplatesPath string
+	WorkDir       string
+	TargetPath    string
+	Values        map[string]any
+	Force         bool
+	// Confirm, when non-nil, is invoked before each overwrite-on-conflict
+	// write under --force. Returning proceed=false skips the write; returning
+	// a non-nil error aborts GenerateManifests.
+	Confirm confirm.Confirmer
+}
+```
+
+(c) Update the conflict-handling block inside `GenerateManifests`:
+
+Replace this block:
+
+```go
+		if st.Exists && (!st.Owned || !st.Matches) {
+			reason := conflict.ReasonUnmarked
+			if st.Owned {
+				reason = conflict.ReasonHashMismatch
+			}
+			conflicts.Add(relPath, reason)
+			if !opts.Force {
+				continue
+			}
+		}
+```
+
+with:
+
+```go
+		if st.Exists && (!st.Owned || !st.Matches) {
+			reason := conflict.ReasonUnmarked
+			action := "overwrite unmarked"
+			if st.Owned {
+				reason = conflict.ReasonHashMismatch
+				action = "overwrite edited"
+			}
+			conflicts.Add(relPath, reason)
+			if !opts.Force {
+				continue
+			}
+			if opts.Confirm != nil {
+				proceed, err := opts.Confirm(action, relPath)
+				if err != nil {
+					return written, conflicts, err
+				}
+				if !proceed {
+					continue
+				}
+			}
+		}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./rollout/...`
+Expected: PASS.
+
+- [ ] **Step 5: Build the whole project**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rollout/rollout.go rollout/rollout_test.go
+git commit -m "rollout: prompt Confirmer before each overwrite under --force"
+```
+
+---
+
+## Task 4: Add `Confirm` to `PruneOpts` and wire it into `Prune`
+
+**Files:**
+- Modify: `rollout/rollout.go`
+- Modify: `rollout/rollout_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `rollout/rollout_test.go`:
+
+```go
+func TestPruneConfirmYes(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	stale := filepath.Join(targetDir, "stale.yaml")
+	mustWriteMarked(t, stale, "kind: Stale\n")
+
+	var calls []string
+	conf := func(action, path string) (bool, error) {
+		calls = append(calls, action+":"+path)
+		return true, nil
+	}
+
+	removed, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Confirm:    conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 || calls[0] != "delete stale:apps/staging/stale.yaml" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if len(removed) != 1 || removed[0] != stale {
+		t.Fatalf("removed = %v, want [%s]", removed, stale)
+	}
+}
+
+func TestPruneConfirmNo(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	stale := filepath.Join(targetDir, "stale.yaml")
+	mustWriteMarked(t, stale, "kind: Stale\n")
+
+	conf := func(action, path string) (bool, error) {
+		return false, nil
+	}
+
+	removed, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Confirm:    conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want empty", removed)
+	}
+	if _, err := os.Stat(stale); err != nil {
+		t.Fatalf("stale file was deleted: %v", err)
+	}
+}
+
+func TestPruneConfirmAbort(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	stale := filepath.Join(targetDir, "stale.yaml")
+	mustWriteMarked(t, stale, "kind: Stale\n")
+
+	conf := func(action, path string) (bool, error) {
+		return false, confirm.ErrAborted
+	}
+
+	_, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Confirm:    conf,
+	})
+	if !errors.Is(err, confirm.ErrAborted) {
+		t.Fatalf("err = %v, want ErrAborted", err)
+	}
+}
+
+func TestPruneOrphanSidecarConfirmNo(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	sidecar := filepath.Join(targetDir, "ghost.json.monotool")
+	mustWrite(t, sidecar, "deadbeef\n")
+
+	var calls []string
+	conf := func(action, path string) (bool, error) {
+		calls = append(calls, action+":"+path)
+		return false, nil
+	}
+
+	removed, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Confirm:    conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 || calls[0] != "remove orphan sidecar:apps/staging/ghost.json.monotool" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want empty", removed)
+	}
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("sidecar was deleted: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `go test ./rollout/...`
+Expected: FAIL with "unknown field Confirm in PruneOpts".
+
+- [ ] **Step 3: Add `Confirm` to `PruneOpts` and wire into `Prune`**
+
+In `rollout/rollout.go`:
+
+(a) Extend `PruneOpts`:
+
+```go
+// PruneOpts drives Prune. DesiredAbs is the set of absolute paths Prune must
+// leave alone (typically: every path GenerateManifests wrote, including
+// sidecars).
+type PruneOpts struct {
+	WorkDir    string
+	TargetPath string
+	DesiredAbs map[string]struct{}
+	Force      bool
+	// Confirm, when non-nil, is invoked before each deletion (stale owned
+	// file or orphan sidecar). Returning proceed=false skips that deletion;
+	// returning a non-nil error aborts Prune.
+	Confirm confirm.Confirmer
+}
+```
+
+(b) In the stale-owned deletion loop, replace:
+
+```go
+		if err := ownership.Remove(o.path); err != nil {
+			return removed, conflicts, err
+		}
+		removed = append(removed, o.path)
+		if filepath.Ext(o.path) == ".json" {
+			removed = append(removed, o.path+ownership.SidecarExt)
+		}
+```
+
+with (note: `o.rel` is already computed during the walk and stored in the `ownedFile` struct):
+
+```go
+		if opts.Confirm != nil {
+			proceed, err := opts.Confirm("delete stale", o.rel)
+			if err != nil {
+				return removed, conflicts, err
+			}
+			if !proceed {
+				continue
+			}
+		}
+		if err := ownership.Remove(o.path); err != nil {
+			return removed, conflicts, err
+		}
+		removed = append(removed, o.path)
+		if filepath.Ext(o.path) == ".json" {
+			removed = append(removed, o.path+ownership.SidecarExt)
+		}
+```
+
+(c) In the orphan-sidecar loop, replace:
+
+```go
+	for _, p := range orphanSidecars {
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return removed, conflicts, err
+		}
+		removed = append(removed, p)
+	}
+```
+
+with:
+
+```go
+	for _, p := range orphanSidecars {
+		if opts.Confirm != nil {
+			rel, relErr := filepath.Rel(opts.WorkDir, p)
+			if relErr != nil {
+				return removed, conflicts, relErr
+			}
+			proceed, err := opts.Confirm("remove orphan sidecar", rel)
+			if err != nil {
+				return removed, conflicts, err
+			}
+			if !proceed {
+				continue
+			}
+		}
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return removed, conflicts, err
+		}
+		removed = append(removed, p)
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./rollout/...`
+Expected: PASS.
+
+- [ ] **Step 5: Build the whole project**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rollout/rollout.go rollout/rollout_test.go
+git commit -m "rollout: prompt Confirmer before each Prune deletion under --force"
+```
+
+---
+
+## Task 5: Thread Confirmer through `Rollout.RollOut` and suppress Warn when prompting
+
+**Files:**
+- Modify: `rollout/rollout.go`
+- Modify: `rollout/rollout_test.go`
+
+This task wires the Confirmer through the orchestration layer and removes the now-redundant `Warn` call when prompting is active.
+
+- [ ] **Step 1: Change the `RollOut` signature and closure**
+
+In `rollout/rollout.go`, change the `RollOut` method:
+
+```go
+func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[string]any, message string, force bool, conf confirm.Confirmer) error {
+```
+
+In the closure body, replace this block:
+
+```go
+	generate := func(workDir string) (added, removed []string, err error) {
+		written, writeConflicts, err := GenerateManifests(ctx, GenerateOpts{
+			TemplatesPath: templatesAbs,
+			WorkDir:       workDir,
+			TargetPath:    r.TargetPath,
+			Values:        values,
+			Force:         force,
+		})
+```
+
+with:
+
+```go
+	generate := func(workDir string) (added, removed []string, err error) {
+		written, writeConflicts, err := GenerateManifests(ctx, GenerateOpts{
+			TemplatesPath: templatesAbs,
+			WorkDir:       workDir,
+			TargetPath:    r.TargetPath,
+			Values:        values,
+			Force:         force,
+			Confirm:       conf,
+		})
+```
+
+Then in the Prune call, replace:
+
+```go
+			pruned, pruneConflicts, err = Prune(ctx, PruneOpts{
+				WorkDir:    workDir,
+				TargetPath: r.TargetPath,
+				DesiredAbs: desired,
+				Force:      force,
+			})
+```
+
+with:
+
+```go
+			pruned, pruneConflicts, err = Prune(ctx, PruneOpts{
+				WorkDir:    workDir,
+				TargetPath: r.TargetPath,
+				DesiredAbs: desired,
+				Force:      force,
+				Confirm:    conf,
+			})
+```
+
+Finally, replace the Warn/Report block:
+
+```go
+		all := mergeConflicts(writeConflicts, pruneConflicts)
+		if !all.Empty() {
+			if force {
+				all.Warn(os.Stderr)
+			} else {
+				all.Report(os.Stderr)
+				return nil, nil, all.Err()
+			}
+		}
+```
+
+with:
+
+```go
+		all := mergeConflicts(writeConflicts, pruneConflicts)
+		if !all.Empty() {
+			switch {
+			case !force:
+				all.Report(os.Stderr)
+				return nil, nil, all.Err()
+			case conf == nil:
+				// --force without a Confirmer: legacy unconditional behavior
+				all.Warn(os.Stderr)
+			}
+			// --force with a Confirmer: each prompt was its own ack, no extra output
+		}
+```
+
+- [ ] **Step 2: Update the CLI call site temporarily**
+
+In `command/rollout/command.go`, find the existing call:
+
+```go
+err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"))
+```
+
+and change to:
+
+```go
+err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"), nil)
+```
+
+The `nil` is a placeholder until Task 6 wires the TTY Confirmer. This keeps the CLI compiling now.
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./...`
+Run: `go test ./...`
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rollout/rollout.go command/rollout/command.go
+git commit -m "rollout: thread Confirmer through RollOut, suppress Warn when prompting"
+```
+
+---
+
+## Task 6: Wire TTY Confirmer into the CLI command
+
+**Files:**
+- Modify: `command/rollout/command.go`
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+- [ ] **Step 1: Add `golang.org/x/term` as a direct dependency**
+
+Run: `go get golang.org/x/term`
+
+This promotes it from indirect to direct and downloads the latest compatible version.
+
+- [ ] **Step 2: Update `command/rollout/command.go`**
+
+Replace the placeholder line:
+
+```go
+err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"), nil)
+```
+
+with the TTY-aware version:
+
+```go
+var conf confirm.Confirmer
+if c.Bool("force") {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return errors.New("--force requires an interactive terminal")
+	}
+	conf = confirm.TTYConfirmer(os.Stdin, os.Stderr)
+}
+
+err = r.RollOut(ctx, cfg.ProjectRoot, values, message, c.Bool("force"), conf)
+if errors.Is(err, confirm.ErrAborted) {
+	fmt.Fprintln(os.Stderr, "rollout aborted by user")
+	return cli.Exit("", 1)
+}
+```
+
+Add the required imports to `command/rollout/command.go`:
+
+```go
+"errors"
+"os"
+
+"github.com/draganm/monotool/rollout/confirm"
+"golang.org/x/term"
+```
+
+(`os` is likely already imported via the signal package, and `errors` may already be there too — confirm before adding and de-duplicate.)
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./...`
+Run: `go test ./...`
+Expected: both pass.
+
+- [ ] **Step 4: Run go mod tidy to clean up the dependency**
+
+Run: `go mod tidy`
+Expected: `go.mod` lists `golang.org/x/term` as a direct dependency (not in the indirect block).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add command/rollout/command.go go.mod go.sum
+git commit -m "rollout: wire TTY confirm prompt for --force"
+```
+
+---
+
+## Task 7: Smoke-test the prompt flow against a local repo
+
+Optional human-driven verification. Skip if you've already exercised the flow.
+
+- [ ] **Step 1: Build a binary**
+
+Run: `go build -o /tmp/monotool-prompt ./`
+Expected: binary at /tmp/monotool-prompt.
+
+- [ ] **Step 2: Set up a local gitops remote with an unrelated file**
+
+```bash
+mkdir -p /tmp/prompt-test
+cd /tmp/prompt-test
+git init --bare remote.git
+git clone remote.git working
+cd working
+mkdir -p apps/staging
+echo "kind: HumanFile" > apps/staging/handwritten.yaml
+git add . && git commit -m "human file"
+git push
+```
+
+- [ ] **Step 3: Configure a `.monotool/config.yaml` in any project**
+
+Point its rollout's `repoUrl` at `/tmp/prompt-test/remote.git` with `pruneTargets: true` and `targetPath: apps/staging`. Templates should generate at least one file at the same path as the handwritten file to force a conflict.
+
+- [ ] **Step 4: Run with `--force` interactively**
+
+Run: `/tmp/monotool-prompt rollout <name> --force -m "smoke test"`
+Expected: prompt for `overwrite unmarked apps/staging/<file>? [y/n/a]`. Try `y`, `n`, and `a` across multiple runs to verify each path.
+
+- [ ] **Step 5: Run with `--force` non-interactively**
+
+Run: `/tmp/monotool-prompt rollout <name> --force -m "smoke" < /dev/null`
+Expected: error `"--force requires an interactive terminal"`.
+
+- [ ] **Step 6: Clean up the test binary and fixtures**
+
+```bash
+rm /tmp/monotool-prompt
+rm -rf /tmp/prompt-test
+```

--- a/docs/superpowers/specs/2026-05-25-gitops-coexistence-design.md
+++ b/docs/superpowers/specs/2026-05-25-gitops-coexistence-design.md
@@ -1,0 +1,223 @@
+# GitOps Repo Coexistence: File-Level Ownership Markers
+
+**Date:** 2026-05-25
+**Status:** Draft
+
+## Problem
+
+Today, `monotool rollout` assumes it is the sole writer of files under each rollout's `targetPath` in the gitops repo. Three behaviors break that assumption when humans or other tools (ArgoCD writebacks, sealed-secrets operators, image updaters, etc.) also commit there:
+
+1. **Same-file overwrite.** `generateManifests` opens every target path with `os.O_TRUNC`, silently clobbering any hand edits a human made between rollouts.
+2. **Directory-level prune.** With `pruneTargets: true`, `rollout.go` calls `os.RemoveAll` on whole subdirectories of `targetPath` before regenerating, wiping any non-monotool files committed there.
+3. **Broad staging.** `gitops.AddFiles` runs `git add .`, so unrelated changes in the working tree (left by another tool that wrote during the clone window, or a human commit not yet pushed) get rolled into monotool's commit.
+
+The result: anyone sharing the gitops repo with monotool risks losing their work without warning.
+
+## Goal
+
+Let monotool and other writers co-exist in the same gitops repo without monotool destroying their files. When monotool *would* destroy something it does not own, it must stop and surface the conflict to a human rather than continuing silently.
+
+## Non-goals
+
+- Merging hand edits back into templates. If a human edits a generated file, monotool's job is to detect the divergence and refuse to overwrite — not to reconcile.
+- Multi-writer locking. Monotool still assumes it has the only in-flight rollout for a given `targetPath` at a time. Cross-rollout coordination is out of scope.
+- Retroactive ownership of files monotool generated before this change ships. The first post-upgrade rollout will treat all existing files as unowned and require `--force` (see Migration).
+
+## Design
+
+### File-level ownership markers
+
+Every file monotool writes carries a marker recording the SHA-256 of its own body. The marker proves "monotool last wrote this file, and here's what it wrote." If the file's current body hashes to the marker's value, no one has touched it since.
+
+**YAML files** (`.yaml`, `.yml`): the marker is a comment on the **first line** of the file:
+
+```yaml
+# monotool-hash: 9f3c1a...e2b
+apiVersion: apps/v1
+kind: Deployment
+...
+```
+
+**JSON files** (`.json`): the marker lives in a **sidecar file** next to the JSON. For `foo.json`, the sidecar is `foo.json.monotool` and contains the hash as a single line of text. The JSON file itself is left untouched.
+
+**Hash computation:** SHA-256 over the file body **excluding the marker line** (YAML) or over the full JSON body (JSON, since its marker is external). Hashing the post-marker body — not the whole file — guarantees that re-running with identical inputs produces a byte-identical file with a byte-identical marker.
+
+### Rollout flow
+
+All work happens in the throwaway clone of the gitops repo. Disk writes and deletions during the rollout never reach the remote unless monotool decides to commit and push at the end — so an abort mid-flow safely discards everything done locally.
+
+For each template the rollout would write:
+
+1. Resolve the target path inside the gitops repo working tree.
+2. If the target path does **not** exist on disk:
+   - Write the file with a freshly-computed marker. Done.
+3. If the target path **does** exist:
+   - Read its marker (header line for YAML, sidecar file for JSON).
+   - **No marker present** → file is not owned by monotool. Record a conflict (`unmarked`) and continue to the next file.
+   - **Marker present, but `hash(current body) != marker hash`** → a human or tool edited the file after monotool last wrote it. Record a conflict (`hash-mismatch`) and continue.
+   - **Marker present and matches** → safe. Overwrite with the new content and a fresh marker.
+4. After visiting every template, if any conflicts were recorded:
+   - Abort the rollout. Do not commit, do not push.
+   - Print the full conflict list to stderr, grouped by reason, with file paths relative to the gitops repo root.
+   - Exit non-zero.
+5. If `--force` was passed on the CLI, conflicts are demoted to warnings: monotool prints the same list but overwrites anyway.
+
+### Pruning (replaces today's `removeOldManifests`)
+
+Pruning runs after writes succeed, only when `pruneTargets: true`. The new algorithm:
+
+1. Walk `targetPath` recursively.
+2. For each regular file found:
+   - If it has a monotool marker (header for YAML, matching sidecar for JSON):
+     - Recompute its hash. If the hash matches the marker, the file is monotool-owned and untouched.
+       - If the file is **not** in the current template set, delete it (and its sidecar, if any). It's a leftover from a previous rollout.
+       - If the file **is** in the current template set, leave it alone — it was just (re)written above.
+     - If the hash does not match the marker, treat as a `hash-mismatch` conflict — same handling as in the write phase (abort without `--force`, warn with `--force` and leave the file alone).
+   - If it has no marker, leave it alone — it isn't ours.
+3. After deletion, remove any directories under `targetPath` that became empty as a result, walking bottom-up. Never remove a directory that still contains anything (owned or not).
+
+JSON sidecars are deleted together with their JSON. An orphan sidecar (sidecar exists but the JSON doesn't) is treated as monotool-owned cruft and removed during prune.
+
+### Git staging
+
+`gitops.AddFiles`'s current `git add .` is replaced with explicit, path-by-path staging:
+
+- For every file monotool **wrote** in this rollout: `git add <path>` (plus the sidecar path if applicable).
+- For every file monotool **deleted** during prune: `git rm <path>` (plus the sidecar path if applicable).
+- Nothing else is staged. If unrelated changes sit in the working tree (e.g., a concurrent writer modified a file outside monotool's path set), they remain unstaged and untouched.
+
+If, after staging, `git status --porcelain` shows no staged changes, monotool skips the commit and push entirely and reports "no changes" — matching today's behavior for empty rollouts.
+
+### CLI surface
+
+- `monotool rollout <name>` — unchanged default behavior, except conflicts now abort.
+- `monotool rollout <name> --force` — demote conflicts to warnings and overwrite anyway. Force is a per-invocation flag only; it is **not** exposed as a config setting in `.monotool/config.yaml`, because the safety guarantee depends on overriding being a deliberate act each time.
+
+### Conflict reporting format
+
+On abort, monotool prints to stderr:
+
+```
+rollout aborted: 3 conflicts detected
+
+unmarked (not owned by monotool):
+  apps/staging/foo/extra-configmap.yaml
+  apps/staging/foo/secret.json
+
+hash-mismatch (edited since last rollout):
+  apps/staging/foo/deployment.yaml
+
+re-run with --force to overwrite, or resolve manually and commit before retrying.
+```
+
+The same list (without the "aborted" header) is printed as a warning when `--force` is used.
+
+## Architecture
+
+Two new packages, plus targeted edits to existing ones.
+
+### New: `rollout/ownership`
+
+Single-purpose package that knows about markers.
+
+- `func ReadMarker(path string) (hash string, found bool, err error)` — reads the marker for a file path, dispatching on extension (YAML header vs JSON sidecar).
+- `func WriteMarked(path string, body []byte) error` — writes a file with its marker, again dispatching on extension. Replaces the raw `os.OpenFile` + write in `generateManifests`.
+- `func ComputeBodyHash(path string, body []byte) string` — exposed so callers can pre-compute hashes when walking the tree during prune.
+- `func StripMarker(body []byte, ext string) []byte` — returns the body that would be hashed (drops the marker comment for YAML, returns input unchanged for JSON).
+- Package-internal constants for the marker prefix (`# monotool-hash: `) and sidecar extension (`.monotool`).
+
+Tests live alongside (`ownership_test.go`) and cover: round-trip write/read for YAML and JSON, marker-missing detection, hash-mismatch detection after manual edit, sidecar orphan handling.
+
+### New: `rollout/conflict`
+
+Holds the conflict-collection and reporting logic so it can be reused between the write phase and the prune phase.
+
+- `type Conflict struct { Path string; Reason ConflictReason }`
+- `type ConflictReason int` with `ReasonUnmarked` and `ReasonHashMismatch`.
+- `type Set struct { ... }` accumulates conflicts and exposes `Add`, `Empty`, `Report(w io.Writer)`, and `Err()` (returns a sentinel error when non-empty).
+
+### Changes to `rollout/rollout.go`
+
+- `generateManifests` no longer opens files directly. Instead, it builds the desired-file map (already does this for `templates`), then for each entry calls into a new helper that performs the existence check, marker check, and `ownership.WriteMarked` call. The helper returns `(written bool, conflict *Conflict)`.
+- `removeOldManifests` is gone. In its place, a new `prune` function walks `targetPath`, consults the desired-file map, and uses `ownership.ReadMarker` + `ComputeBodyHash` to decide which files to delete.
+- The `Rollout` struct gains no new YAML fields. `PruneTargets` keeps its current semantics; `--force` is a CLI flag threaded through as an argument to `RollOut`.
+- `RollOut`'s signature gains a `force bool` parameter. Callers in `command/` pass the CLI flag value through.
+
+### Changes to `rollout/gitops/operations.go`
+
+- `AddFiles(ctx, dir)` is replaced (or augmented) with `StageChanges(ctx, dir string, added []string, removed []string) error`, which runs `git add` / `git rm` on the explicit paths. The existing `AddFiles` may be removed entirely if no other caller exists.
+- The gitea and github rollout wrappers in `rollout/gitea/` and `rollout/github/` are updated to call `StageChanges` with the lists returned from `generateManifests` and `prune`.
+
+### Changes to `command/`
+
+- The `rollout` CLI command gains a `--force` boolean flag.
+- Flag value is passed into `Rollout.RollOut`.
+
+## Data flow
+
+```
+              ┌────────────────────────────┐
+templates ──▶ │ generateManifests          │
+              │  for each template:        │
+              │   read marker on disk      │
+              │   if conflict → record     │
+              │   else        → WriteMarked│
+              └─────────────┬──────────────┘
+                            │ (writtenPaths, conflictSet)
+                            ▼
+                  ┌──────────────────┐
+                  │ prune (optional) │
+                  │  walk targetPath │
+                  │  delete orphans  │
+                  │  record conflicts│
+                  └─────────┬────────┘
+                            │ (removedPaths, conflictSet)
+                            ▼
+            ┌────────────────────────────────┐
+            │ conflictSet.Empty() && !force? │
+            │   yes → abort, print report    │
+            │   no  → continue (warn if any) │
+            └────────────────┬───────────────┘
+                             ▼
+                ┌────────────────────────┐
+                │ StageChanges           │
+                │  git add writtenPaths  │
+                │  git rm removedPaths   │
+                └───────────┬────────────┘
+                            ▼
+                     commit + push
+```
+
+## Error handling
+
+- I/O errors (read marker, write file, walk dir) propagate as wrapped errors and abort the rollout immediately — they are not conflicts.
+- Malformed markers (e.g., a YAML file starts with `# monotool-hash:` but the value isn't hex) are treated as `hash-mismatch`. Better to flag suspiciously-shaped markers than to ignore them.
+- Sidecar I/O errors when the JSON itself reads cleanly are propagated, not converted to conflicts — a broken sidecar suggests a deeper problem than a co-committer.
+
+## Testing
+
+Unit tests in each new package, plus integration tests in `rollout/` that exercise the full flow against a temporary working tree:
+
+- Round-trip: write a YAML and a JSON, read back markers, hash matches.
+- First-write into empty `targetPath`: succeeds, all files marked.
+- Re-rollout with no changes: hashes match, no conflicts, no commits (empty diff).
+- Re-rollout after a hand edit to a YAML: aborts with `hash-mismatch`. With `--force`: warning printed, file overwritten.
+- Re-rollout with an extra co-committed file in `targetPath`: file survives. Prune does not delete it.
+- Re-rollout where a previously-generated YAML is no longer in the templates: prune deletes it. Same scenario but file was hand-edited after monotool last wrote it: prune aborts (or warns + leaves alone, with `--force`).
+- JSON sidecar lifecycle: created on first write, updated on overwrite, deleted on prune, orphaned sidecar removed.
+- `git add` granularity: an unrelated file in the working tree is **not** staged.
+
+## Migration
+
+Existing rollouts have no markers on already-generated files. The first run after upgrading will see every file as `unmarked` and abort.
+
+Two paths forward, chosen by the operator:
+
+1. **Run once with `--force`.** Every file gets re-written with a fresh marker. Subsequent rollouts return to the normal safe mode.
+2. **Add a one-shot `monotool adopt <rollout>` command** that walks `targetPath`, computes hashes for all files matching the rollout's template set, and writes markers in place without touching the body. The same desired-file mapping logic from `generateManifests` is reused — this command is essentially `generateManifests` with "write marker, keep body" instead of "write template, write marker."
+
+`adopt` is the better operator experience but adds CLI surface. Recommend shipping with `--force` only and adding `adopt` if migration friction is real.
+
+## Open questions
+
+None blocking. Marker syntax (`# monotool-hash: `) and sidecar extension (`.monotool`) are bikesheddable but unimportant — picked for readability and grep-ability.

--- a/docs/superpowers/specs/2026-05-26-force-interactive-confirm-design.md
+++ b/docs/superpowers/specs/2026-05-26-force-interactive-confirm-design.md
@@ -1,0 +1,238 @@
+# Interactive Confirmation for `--force` Rollouts
+
+**Date:** 2026-05-26
+**Status:** Draft
+**Depends on:** [2026-05-25-gitops-coexistence-design.md](./2026-05-25-gitops-coexistence-design.md)
+
+## Problem
+
+Today `--force` is binary: pass it and monotool silently performs every destructive action across the rollout (overwriting unowned files, overwriting hand-edited owned files, deleting stale files). The flag is the operator's only signal of intent. A typo in a template path or an unexpected manifest in the gitops repo can lead to silent destruction the operator never sees until they look at git history.
+
+Operators want fine-grained control: when `--force` is in play, decide each destructive action individually.
+
+## Goal
+
+Under `--force`, prompt the operator to confirm every destructive action one at a time. Allow per-file approve/skip and a global abort. Preserve all other gitops-coexistence guarantees, including the "never delete a hash-mismatched file in prune" safety rule.
+
+## Non-goals
+
+- "yes-to-all" / "no-to-all" shortcuts. Plain y/n/abort only.
+- Reading inputs from a config file or environment variable. The prompt is interactive only.
+- Replacing the existing non-interactive `--force` for CI. Non-TTY `--force` becomes an error (see Non-TTY behavior below); CI workflows need a different mechanism if they want forced rollouts, and that's out of scope for this design.
+- Prompting under non-`--force` rollouts. Without `--force`, conflicts abort as today — there's nothing destructive to confirm.
+
+## Design
+
+### The Confirmer
+
+A single function type expresses the prompt contract:
+
+```go
+// Confirmer asks the user whether to perform a destructive action.
+// Returns proceed=true to perform the action, proceed=false to skip just
+// this one, or a non-nil error to abort the rollout entirely. A nil
+// Confirmer means "no prompting, proceed unconditionally" (preserves the
+// pre-prompt behavior for tests).
+type Confirmer func(action, path string) (proceed bool, err error)
+```
+
+`action` is a short label embedded in the prompt text. The four values used by the rollout flow are:
+
+| action               | When it's prompted                                          |
+|----------------------|-------------------------------------------------------------|
+| `overwrite unmarked` | GenerateManifests is about to write over a file with no marker |
+| `overwrite edited`   | GenerateManifests is about to write over a hash-mismatched owned file |
+| `delete stale`       | Prune is about to delete a stale owned file (hash matches)  |
+| `remove orphan sidecar` | Prune is about to delete a `.monotool` sidecar whose JSON sibling is gone |
+
+`path` is the gitops-repo-relative path of the file the action targets — the same form used in conflict reports.
+
+### Sentinel: `ErrAborted`
+
+```go
+var ErrAborted = errors.New("rollout aborted by user")
+```
+
+Returned by `Confirmer` when the operator picks the abort option. The rollout closure surfaces it up; the CLI command catches it and exits cleanly with a non-zero status and a one-line stderr message ("rollout aborted by user"), without a Go-style error wrap chain.
+
+### Where the Confirmer plugs in
+
+Two new fields:
+
+- `GenerateOpts.Confirm Confirmer` — checked inside `GenerateManifests` before each conflict-overwrite write.
+- `PruneOpts.Confirm Confirmer` — checked inside `Prune` before each stale-owned deletion and before each orphan-sidecar removal.
+
+Both call the Confirmer immediately before performing the destructive action. The result drives behavior:
+
+- `proceed=true, err=nil` → perform the action, append the resulting path(s) to `written` / `removed`.
+- `proceed=false, err=nil` → skip the action, do not append paths. The file remains in the working tree untouched, won't be staged, won't appear in the commit.
+- `err != nil` → propagate immediately. `GenerateManifests` and `Prune` return `(written-so-far, conflicts, err)` and `(removed-so-far, conflicts, err)` respectively. The rollout closure surfaces the error and skips StageChanges/commit/push entirely.
+
+For non-conflict paths (clean writes, unowned-file no-ops), the Confirmer is **not** called. Only the four prompt-worthy actions above hit it.
+
+### CLI wiring
+
+In `command/rollout/command.go`, when `--force` is set:
+
+1. Check stdin is a terminal:
+
+   ```go
+   if !term.IsTerminal(int(os.Stdin.Fd())) {
+       return errors.New("--force requires an interactive terminal")
+   }
+   ```
+
+   (Uses `golang.org/x/term`, which is already in the module's indirect dependencies.)
+
+2. Construct a `confirm.TTYConfirmer(os.Stdin, os.Stderr)` and pass it through `RollOut`.
+
+3. After `RollOut` returns, if the error is (or wraps) `confirm.ErrAborted`, print `"rollout aborted by user"` to stderr and exit non-zero — but with a clean message, not the full wrapped chain.
+
+When `--force` is not set, no Confirmer is constructed; conflicts go through the existing abort-with-report path unchanged.
+
+### Threading through RollOut
+
+`Rollout.RollOut` gains one more parameter:
+
+```go
+func (r *Rollout) RollOut(
+    ctx context.Context,
+    projectRoot string,
+    values map[string]any,
+    message string,
+    force bool,
+    confirm confirm.Confirmer,
+) error
+```
+
+The closure constructs `GenerateOpts` and `PruneOpts` with `Confirm: confirm`. Callers pass `nil` when `--force` is off (or in tests that want unconditional behavior).
+
+### TTY prompt UX
+
+A short header before the first prompt summarizes scope:
+
+```
+--force review: 5 action(s) to confirm one at a time
+```
+
+Then, per action:
+
+```
+overwrite edited apps/staging/deploy.yaml? [y/n/a] 
+```
+
+Input is read line-by-line from `os.Stdin`. The first non-whitespace character is lowercased; subsequent characters are ignored. Mapping:
+
+- `y` → proceed
+- `n` → skip
+- `a` → abort
+- Anything else (including empty line) → reprint the prompt
+
+EOF on stdin (e.g., Ctrl-D) → abort.
+
+The summary header is printed by the CLI command before invoking `RollOut`, using `len(writeConflicts) + len(pruneConflicts)` — except that information isn't known until inside the closure. Two options:
+
+1. Compute the count up-front via a "dry-run" walk (extra I/O, but produces an accurate header).
+2. Skip the upfront count and just emit a one-line `"--force review: confirming each destructive action"` header.
+
+Going with (2). The expense of an extra walk to print a number isn't worth it, and the operator sees the count implicitly from the conflict warning that already prints before prompting begins.
+
+### `confirm` package layout
+
+A small new package `rollout/confirm` contains:
+
+- `type Confirmer func(action, path string) (bool, error)`
+- `var ErrAborted = errors.New("rollout aborted by user")`
+- `func TTYConfirmer(in io.Reader, out io.Writer) Confirmer` — the stdin-backed implementation. Takes `io.Reader`/`io.Writer` so tests inject a `strings.Reader` and `bytes.Buffer`.
+
+`GenerateOpts.Confirm` and `PruneOpts.Confirm` are typed `confirm.Confirmer`. A nil value means "no prompting, proceed unconditionally" — tests that want to skip prompting just leave the field zero-valued.
+
+### Interaction with the existing Warn output
+
+Today, when `--force` succeeds, the rollout closure calls `conflicts.Warn(os.Stderr)` after the destructive actions complete. With prompting, this becomes redundant — each prompt is its own surface of the conflict. The rollout closure should **suppress the Warn output when a Confirmer is in use**, because every approval was already an explicit user choice.
+
+Concretely: in the closure,
+
+```go
+if !all.Empty() {
+    if force {
+        if confirm == nil {
+            all.Warn(os.Stderr)  // legacy: --force with no prompting (e.g., a future --yes)
+        }
+        // else: per-prompt acknowledgement already happened
+    } else {
+        all.Report(os.Stderr)
+        return nil, nil, all.Err()
+    }
+}
+```
+
+### Edge cases
+
+- **Confirmer present but `force=false`.** Not a real path: the CLI only constructs a Confirmer when `--force` is set. If a caller wires it up manually it's harmless — `GenerateManifests` and `Prune` only invoke the Confirmer at conflict sites, and without `--force` they hit the conflict-abort path before reaching any destructive action.
+- **Operator skips an overwrite of a JSON sidecar's owner JSON.** Skipping the JSON write also skips writing the sidecar. The existing sidecar (if any) keeps its old hash, which now mismatches — next rollout will flag it as hash-mismatch. This is consistent and expected: skipping means "leave it alone."
+- **Operator skips a deletion that monotool's templates have moved.** The stale file remains. Next rollout sees it as still-owned-but-not-in-templates and offers it for deletion again.
+- **Operator aborts mid-stream.** Some files may have been written or deleted before the abort. Those changes exist in the working tree of the throwaway clone — they never reach the remote because StageChanges/commit/push are skipped on error. This is consistent with the existing "abort discards local work" guarantee.
+
+## Architecture summary
+
+```
+       ┌──────────────────┐
+CLI ── │ build Confirmer  │── TTYConfirmer(stdin, stderr)
+       │ (only on --force)│
+       └────────┬─────────┘
+                ▼
+       ┌──────────────────────────────┐
+       │ Rollout.RollOut(... confirm) │
+       └────────┬─────────────────────┘
+                │
+                ▼
+       ┌────────────────────────────────────────┐
+       │ generate closure:                      │
+       │   GenerateManifests(opts.Confirm=...)  │
+       │   Prune(opts.Confirm=...)              │
+       │   on confirm-skip: omit path           │
+       │   on confirm-error: propagate          │
+       └────────┬───────────────────────────────┘
+                ▼
+       StageChanges (only paths the user said yes to)
+                ▼
+       commit + push
+```
+
+## Error handling
+
+- I/O errors from `Confirmer` (broken stdin pipe etc.) propagate as the abort path. Don't try to recover.
+- `ErrAborted` is the documented abort sentinel. Callers check `errors.Is(err, confirm.ErrAborted)` to render the friendly message.
+- All other errors retain today's wrapping behavior.
+
+## Testing
+
+`rollout/confirm/confirm_test.go`:
+
+- `TestTTYConfirmerYes` — input `"y\n"` → `(true, nil)`.
+- `TestTTYConfirmerNo` — input `"n\n"` → `(false, nil)`.
+- `TestTTYConfirmerAbort` — input `"a\n"` → `(false, ErrAborted)`.
+- `TestTTYConfirmerRepromptsOnGarbage` — input `"x\n\nq\n y\n"` (or similar) → eventually `(true, nil)`, with prompt printed multiple times to the buffer.
+- `TestTTYConfirmerEOFAborts` — empty input → `(false, ErrAborted)`.
+- `TestTTYConfirmerPromptText` — verifies the prompt buffer contains `"overwrite edited apps/foo/x.yaml? [y/n/a]"` (action and path included).
+
+`rollout/rollout_test.go` additions:
+
+- `TestGenerateManifestsConfirmYes` — Confirmer returns `(true, nil)`; verify overwrite happens and `written` contains the path.
+- `TestGenerateManifestsConfirmNo` — Confirmer returns `(false, nil)`; verify the file is left untouched and `written` does NOT contain the path.
+- `TestGenerateManifestsConfirmAbort` — Confirmer returns `(false, ErrAborted)`; verify the error propagates and no further writes happen.
+- `TestPruneConfirmYes` / `TestPruneConfirmNo` / `TestPruneConfirmAbort` — analogous for the deletion path.
+- `TestPruneOrphanSidecarConfirmNo` — Confirmer returns `(false, nil)` for an orphan sidecar; verify the sidecar remains on disk.
+
+CLI behavior (`command/rollout/command.go`): no new unit tests. Manual verification covers the TTY detection and ErrAborted handling.
+
+## Migration
+
+No data migration. Existing rollouts work unchanged. The first user who runs `--force` in their next rollout will see prompts; that's the new normal.
+
+If someone was relying on `--force` in a non-interactive environment, their first run will fail with the new error message. Document this in the README under the rollout command.
+
+## Open questions
+
+None blocking. The Confirmer interface is intentionally narrow so a future `--yes` flag (skip prompts, proceed unconditionally) could plug in by passing `nil` instead of a TTY Confirmer — but that's a separate spec if anyone needs it.

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
             pname = "monotool";
             version = self.shortRev or self.dirtyShortRev or "dev";
             src = ./.;
-            vendorHash = "sha256-hUaKhIPE585dq3ZSNi/Wed9i+FoOucb1KEDn3bb00fg=";
+            vendorHash = "sha256-0yNbNeokGAqQhkK0hurcA4Ef+7cUTDcogohvfa6Cp+Q=";
           };
           default = self.packages.${system}.monotool;
         };

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 require (
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/moby/patternmatcher v0.6.1
+	golang.org/x/term v0.43.0
 )
 
 require (
@@ -90,7 +91,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38 // indirect

--- a/go.sum
+++ b/go.sum
@@ -340,13 +340,13 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
-golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/term v0.39.0 h1:RclSuaJf32jOqZz74CkPA9qFuVTX7vhLlpfj/IGWlqY=
-golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/rollout/confirm/confirm.go
+++ b/rollout/confirm/confirm.go
@@ -1,0 +1,16 @@
+package confirm
+
+import (
+	"errors"
+)
+
+// Confirmer asks the user whether to perform a destructive action.
+// Returns proceed=true to perform the action, proceed=false to skip just
+// this one, or a non-nil error to abort the rollout entirely. A nil
+// Confirmer means "no prompting, proceed unconditionally".
+type Confirmer func(action, path string) (proceed bool, err error)
+
+// ErrAborted is returned by a Confirmer when the user picks the abort
+// option. Callers should check via errors.Is and render a friendly message
+// rather than a wrapped error chain.
+var ErrAborted = errors.New("rollout aborted by user")

--- a/rollout/confirm/confirm.go
+++ b/rollout/confirm/confirm.go
@@ -1,7 +1,11 @@
 package confirm
 
 import (
+	"bufio"
 	"errors"
+	"fmt"
+	"io"
+	"strings"
 )
 
 // Confirmer asks the user whether to perform a destructive action.
@@ -14,3 +18,36 @@ type Confirmer func(action, path string) (proceed bool, err error)
 // option. Callers should check via errors.Is and render a friendly message
 // rather than a wrapped error chain.
 var ErrAborted = errors.New("rollout aborted by user")
+
+// TTYConfirmer returns a Confirmer that prompts on out and reads decisions
+// from in line-by-line. The first non-whitespace character of each input
+// line is lowercased and mapped: 'y' = proceed, 'n' = skip, 'a' = abort.
+// Anything else reprints the prompt. EOF on in aborts.
+func TTYConfirmer(in io.Reader, out io.Writer) Confirmer {
+	br := bufio.NewReader(in)
+	return func(action, path string) (bool, error) {
+		for {
+			fmt.Fprintf(out, "%s %s? [y/n/a] ", action, path)
+			line, err := br.ReadString('\n')
+			if err == io.EOF && line == "" {
+				return false, ErrAborted
+			}
+			if err != nil && err != io.EOF {
+				return false, fmt.Errorf("read confirmation: %w", err)
+			}
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			switch strings.ToLower(trimmed)[0] {
+			case 'y':
+				return true, nil
+			case 'n':
+				return false, nil
+			case 'a':
+				return false, ErrAborted
+			}
+			// otherwise, loop and reprompt
+		}
+	}
+}

--- a/rollout/confirm/confirm_test.go
+++ b/rollout/confirm/confirm_test.go
@@ -1,0 +1,88 @@
+package confirm
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTTYConfirmerYes(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("y\n"), out)
+	proceed, err := c("delete stale", "apps/foo/x.yaml")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !proceed {
+		t.Fatal("proceed = false, want true")
+	}
+}
+
+func TestTTYConfirmerNo(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("n\n"), out)
+	proceed, err := c("delete stale", "apps/foo/x.yaml")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if proceed {
+		t.Fatal("proceed = true, want false")
+	}
+}
+
+func TestTTYConfirmerAbort(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("a\n"), out)
+	proceed, err := c("delete stale", "apps/foo/x.yaml")
+	if !errors.Is(err, ErrAborted) {
+		t.Fatalf("err = %v, want ErrAborted", err)
+	}
+	if proceed {
+		t.Fatal("proceed = true, want false")
+	}
+}
+
+func TestTTYConfirmerRepromptsOnGarbage(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("\nxyz\ny\n"), out)
+	proceed, err := c("overwrite edited", "apps/foo/x.yaml")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !proceed {
+		t.Fatal("proceed = false, want true")
+	}
+	prompts := strings.Count(out.String(), "[y/n/a]")
+	if prompts < 3 {
+		t.Fatalf("expected at least 3 prompts, got %d, output:\n%s", prompts, out.String())
+	}
+}
+
+func TestTTYConfirmerEOFAborts(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader(""), out)
+	proceed, err := c("delete stale", "apps/foo/x.yaml")
+	if !errors.Is(err, ErrAborted) {
+		t.Fatalf("err = %v, want ErrAborted", err)
+	}
+	if proceed {
+		t.Fatal("proceed = true, want false")
+	}
+}
+
+func TestTTYConfirmerPromptText(t *testing.T) {
+	out := new(bytes.Buffer)
+	c := TTYConfirmer(strings.NewReader("y\n"), out)
+	_, _ = c("overwrite edited", "apps/staging/deploy.yaml")
+	got := out.String()
+	if !strings.Contains(got, "overwrite edited") {
+		t.Errorf("prompt missing action label: %q", got)
+	}
+	if !strings.Contains(got, "apps/staging/deploy.yaml") {
+		t.Errorf("prompt missing path: %q", got)
+	}
+	if !strings.Contains(got, "[y/n/a]") {
+		t.Errorf("prompt missing choices: %q", got)
+	}
+}

--- a/rollout/conflict/conflict.go
+++ b/rollout/conflict/conflict.go
@@ -71,17 +71,26 @@ func (s *Set) Items() []Conflict {
 	return out
 }
 
-// Report writes a human-readable conflict report to w, grouped by reason with
-// paths sorted within each group. Reasons appear in fixed order: unmarked,
-// then hash-mismatch.
+// Report writes the abort-mode conflict report to w. Use when conflicts will
+// cause the rollout to fail.
 func (s *Set) Report(w io.Writer) {
+	fmt.Fprintf(w, "rollout aborted: %d conflict(s) detected\n\n", len(s.items))
+	s.writeGroups(w)
+	fmt.Fprintln(w, "re-run with --force to overwrite, or resolve manually and commit before retrying.")
+}
+
+// Warn writes the force-mode conflict report to w. Use when --force is in
+// effect and the rollout is proceeding despite the conflicts.
+func (s *Set) Warn(w io.Writer) {
+	fmt.Fprintf(w, "warning: %d conflict(s) detected, --force overwriting\n\n", len(s.items))
+	s.writeGroups(w)
+}
+
+func (s *Set) writeGroups(w io.Writer) {
 	byReason := map[Reason][]string{}
 	for _, c := range s.items {
 		byReason[c.Reason] = append(byReason[c.Reason], c.Path)
 	}
-
-	fmt.Fprintf(w, "rollout aborted: %d conflict(s) detected\n\n", len(s.items))
-
 	for _, r := range []Reason{ReasonUnmarked, ReasonHashMismatch} {
 		paths := byReason[r]
 		if len(paths) == 0 {
@@ -99,6 +108,4 @@ func (s *Set) Report(w io.Writer) {
 		}
 		fmt.Fprintln(w)
 	}
-
-	fmt.Fprintln(w, "re-run with --force to overwrite, or resolve manually and commit before retrying.")
 }

--- a/rollout/conflict/conflict.go
+++ b/rollout/conflict/conflict.go
@@ -1,0 +1,97 @@
+package conflict
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Reason describes why a file is in conflict.
+type Reason int
+
+const (
+	// ReasonUnmarked means the file exists in targetPath but has no monotool
+	// marker — it was not last written by monotool.
+	ReasonUnmarked Reason = iota
+	// ReasonHashMismatch means the file has a marker but its current body's
+	// hash does not match the marker hash — it was edited since monotool last
+	// wrote it.
+	ReasonHashMismatch
+)
+
+func (r Reason) String() string {
+	switch r {
+	case ReasonUnmarked:
+		return "unmarked"
+	case ReasonHashMismatch:
+		return "hash-mismatch"
+	default:
+		return "unknown"
+	}
+}
+
+// Conflict is a single in-flight conflict detected during a rollout.
+type Conflict struct {
+	Path   string
+	Reason Reason
+}
+
+// Set accumulates conflicts across the rollout flow.
+type Set struct {
+	items []Conflict
+}
+
+// New returns an empty Set.
+func New() *Set { return &Set{} }
+
+// Add appends a conflict.
+func (s *Set) Add(path string, reason Reason) {
+	s.items = append(s.items, Conflict{Path: path, Reason: reason})
+}
+
+// Empty reports whether the set has zero conflicts.
+func (s *Set) Empty() bool { return len(s.items) == 0 }
+
+// ErrConflicts is the sentinel returned by Err when conflicts were collected.
+var ErrConflicts = errors.New("rollout aborted: file ownership conflicts")
+
+// Err returns ErrConflicts when the set is non-empty, otherwise nil.
+func (s *Set) Err() error {
+	if s.Empty() {
+		return nil
+	}
+	return ErrConflicts
+}
+
+// Report writes a human-readable conflict report to w, grouped by reason with
+// paths sorted within each group. Reasons appear in fixed order: unmarked,
+// then hash-mismatch.
+func (s *Set) Report(w io.Writer) {
+	byReason := map[Reason][]string{}
+	for _, c := range s.items {
+		byReason[c.Reason] = append(byReason[c.Reason], c.Path)
+	}
+
+	fmt.Fprintf(w, "rollout aborted: %d conflict(s) detected\n\n", len(s.items))
+
+	for _, r := range []Reason{ReasonUnmarked, ReasonHashMismatch} {
+		paths := byReason[r]
+		if len(paths) == 0 {
+			continue
+		}
+		sort.Strings(paths)
+		switch r {
+		case ReasonUnmarked:
+			fmt.Fprintln(w, "unmarked (not owned by monotool):")
+		case ReasonHashMismatch:
+			fmt.Fprintln(w, "hash-mismatch (edited since last rollout):")
+		}
+		for _, p := range paths {
+			fmt.Fprintf(w, "  %s\n", p)
+		}
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintln(w, "re-run with --force to overwrite, or resolve manually and commit before retrying.")
+}

--- a/rollout/conflict/conflict.go
+++ b/rollout/conflict/conflict.go
@@ -64,6 +64,13 @@ func (s *Set) Err() error {
 	return ErrConflicts
 }
 
+// Items returns a copy of the collected conflicts.
+func (s *Set) Items() []Conflict {
+	out := make([]Conflict, len(s.items))
+	copy(out, s.items)
+	return out
+}
+
 // Report writes a human-readable conflict report to w, grouped by reason with
 // paths sorted within each group. Reasons appear in fixed order: unmarked,
 // then hash-mismatch.

--- a/rollout/conflict/conflict_test.go
+++ b/rollout/conflict/conflict_test.go
@@ -1,0 +1,67 @@
+package conflict
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestEmptySet(t *testing.T) {
+	s := New()
+	if !s.Empty() {
+		t.Fatal("expected empty set")
+	}
+	if s.Err() != nil {
+		t.Fatal("expected nil Err on empty set")
+	}
+}
+
+func TestAddAndErr(t *testing.T) {
+	s := New()
+	s.Add("apps/foo/x.yaml", ReasonUnmarked)
+	if s.Empty() {
+		t.Fatal("expected non-empty set")
+	}
+	if s.Err() == nil {
+		t.Fatal("expected error on non-empty set")
+	}
+}
+
+func TestReportGroupsByReason(t *testing.T) {
+	s := New()
+	s.Add("apps/foo/a.yaml", ReasonUnmarked)
+	s.Add("apps/foo/b.json", ReasonUnmarked)
+	s.Add("apps/foo/c.yaml", ReasonHashMismatch)
+
+	buf := new(bytes.Buffer)
+	s.Report(buf)
+	out := buf.String()
+
+	if !strings.Contains(out, "unmarked") {
+		t.Errorf("want 'unmarked' header, got: %s", out)
+	}
+	if !strings.Contains(out, "hash-mismatch") {
+		t.Errorf("want 'hash-mismatch' header, got: %s", out)
+	}
+	for _, p := range []string{"a.yaml", "b.json", "c.yaml"} {
+		if !strings.Contains(out, p) {
+			t.Errorf("want %q in report, got: %s", p, out)
+		}
+	}
+}
+
+func TestReportPathsSortedWithinReason(t *testing.T) {
+	s := New()
+	s.Add("apps/z.yaml", ReasonUnmarked)
+	s.Add("apps/a.yaml", ReasonUnmarked)
+
+	buf := new(bytes.Buffer)
+	s.Report(buf)
+	out := buf.String()
+
+	aIdx := strings.Index(out, "apps/a.yaml")
+	zIdx := strings.Index(out, "apps/z.yaml")
+	if aIdx < 0 || zIdx < 0 || aIdx > zIdx {
+		t.Fatalf("expected a.yaml before z.yaml in report; got:\n%s", out)
+	}
+}

--- a/rollout/conflict/conflict_test.go
+++ b/rollout/conflict/conflict_test.go
@@ -65,3 +65,28 @@ func TestReportPathsSortedWithinReason(t *testing.T) {
 		t.Fatalf("expected a.yaml before z.yaml in report; got:\n%s", out)
 	}
 }
+
+func TestWarnOmitsAbortFraming(t *testing.T) {
+	s := New()
+	s.Add("apps/foo/a.yaml", ReasonUnmarked)
+	s.Add("apps/foo/b.yaml", ReasonHashMismatch)
+
+	buf := new(bytes.Buffer)
+	s.Warn(buf)
+	out := buf.String()
+
+	if strings.Contains(out, "rollout aborted") {
+		t.Errorf("warn should not mention 'rollout aborted'; got:\n%s", out)
+	}
+	if strings.Contains(out, "re-run with --force") {
+		t.Errorf("warn should not suggest --force; got:\n%s", out)
+	}
+	if !strings.Contains(out, "warning:") {
+		t.Errorf("warn should start with 'warning:'; got:\n%s", out)
+	}
+	for _, p := range []string{"a.yaml", "b.yaml"} {
+		if !strings.Contains(out, p) {
+			t.Errorf("want %q in warning, got: %s", p, out)
+		}
+	}
+}

--- a/rollout/gitea/roll_out_to_gitea.go
+++ b/rollout/gitea/roll_out_to_gitea.go
@@ -15,7 +15,7 @@ type GiteaRollout struct {
 	RepoURL string `yaml:"repoUrl"`
 }
 
-func (g *GiteaRollout) RollOut(ctx context.Context, message string, generate func(dir string) error) error {
+func (g *GiteaRollout) RollOut(ctx context.Context, message string, generate func(dir string) (added, removed []string, err error)) error {
 	td, err := os.MkdirTemp("", "")
 	if err != nil {
 		return fmt.Errorf("could not create a temp dir: %w", err)
@@ -39,7 +39,7 @@ func (g *GiteaRollout) RollOut(ctx context.Context, message string, generate fun
 		return err
 	}
 
-	err = generate(td)
+	_, _, err = generate(td)
 	if err != nil {
 		return fmt.Errorf("could not generate manifests: %w", err)
 	}

--- a/rollout/gitea/roll_out_to_gitea.go
+++ b/rollout/gitea/roll_out_to_gitea.go
@@ -20,44 +20,41 @@ func (g *GiteaRollout) RollOut(ctx context.Context, message string, generate fun
 	if err != nil {
 		return fmt.Errorf("could not create a temp dir: %w", err)
 	}
+	defer os.RemoveAll(td)
 
-	defer func() {
-		os.RemoveAll(td)
-	}()
-
-	err = gitops.CloneRepo(ctx, g.RepoURL, td)
-	if err != nil {
+	if err := gitops.CloneRepo(ctx, g.RepoURL, td); err != nil {
 		return err
 	}
 
 	commitTime := time.Now().Format("2006-01-02-15-04-05")
-
 	branchName := fmt.Sprintf("rollout-%s", commitTime)
-
-	err = gitops.CreateBranch(ctx, td, branchName)
-	if err != nil {
+	if err := gitops.CreateBranch(ctx, td, branchName); err != nil {
 		return err
 	}
 
-	_, _, err = generate(td)
+	added, removed, err := generate(td)
 	if err != nil {
 		return fmt.Errorf("could not generate manifests: %w", err)
 	}
 
-	err = gitops.AddFiles(ctx, td)
+	if err := gitops.StageChanges(ctx, td, added, removed); err != nil {
+		return fmt.Errorf("could not stage changes: %w", err)
+	}
+
+	hasChanges, err := gitops.HasStagedChanges(ctx, td)
 	if err != nil {
-		return fmt.Errorf("could not add generated files: %w", err)
+		return err
+	}
+	if !hasChanges {
+		fmt.Println("no changes to roll out")
+		return nil
 	}
 
 	commitMessage := fmt.Sprintf("rollout %s\n\n%s", commitTime, message)
-
-	err = gitops.CreateCommit(ctx, td, commitMessage)
-	if err != nil {
+	if err := gitops.CreateCommit(ctx, td, commitMessage); err != nil {
 		return fmt.Errorf("could not create commit: %w", err)
 	}
-
-	err = gitops.PushToOrigin(ctx, td, branchName)
-	if err != nil {
+	if err := gitops.PushToOrigin(ctx, td, branchName); err != nil {
 		return fmt.Errorf("could not push: %w", err)
 	}
 
@@ -65,9 +62,7 @@ func (g *GiteaRollout) RollOut(ctx context.Context, message string, generate fun
 	if err != nil {
 		return fmt.Errorf("could not create PR: %w", err)
 	}
-
 	fmt.Println(output)
-
 	return nil
 }
 

--- a/rollout/github/roll_out_to_github.go
+++ b/rollout/github/roll_out_to_github.go
@@ -16,7 +16,7 @@ type GitHubRollout struct {
 	Base    string `yaml:"base"`
 }
 
-func (g *GitHubRollout) RollOut(ctx context.Context, message string, generate func(dir string) error) error {
+func (g *GitHubRollout) RollOut(ctx context.Context, message string, generate func(dir string) (added, removed []string, err error)) error {
 	td, err := os.MkdirTemp("", "")
 	if err != nil {
 		return fmt.Errorf("could not create a temp dir: %w", err)
@@ -40,7 +40,7 @@ func (g *GitHubRollout) RollOut(ctx context.Context, message string, generate fu
 		return err
 	}
 
-	err = generate(td)
+	_, _, err = generate(td)
 	if err != nil {
 		return fmt.Errorf("could not generate manifests: %w", err)
 	}

--- a/rollout/github/roll_out_to_github.go
+++ b/rollout/github/roll_out_to_github.go
@@ -21,44 +21,41 @@ func (g *GitHubRollout) RollOut(ctx context.Context, message string, generate fu
 	if err != nil {
 		return fmt.Errorf("could not create a temp dir: %w", err)
 	}
+	defer os.RemoveAll(td)
 
-	defer func() {
-		os.RemoveAll(td)
-	}()
-
-	err = gitops.CloneRepo(ctx, g.RepoURL, td)
-	if err != nil {
+	if err := gitops.CloneRepo(ctx, g.RepoURL, td); err != nil {
 		return err
 	}
 
 	commitTime := time.Now().Format("2006-01-02-15-04-05")
-
 	branchName := fmt.Sprintf("rollout-%s", commitTime)
-
-	err = gitops.CreateBranch(ctx, td, branchName)
-	if err != nil {
+	if err := gitops.CreateBranch(ctx, td, branchName); err != nil {
 		return err
 	}
 
-	_, _, err = generate(td)
+	added, removed, err := generate(td)
 	if err != nil {
 		return fmt.Errorf("could not generate manifests: %w", err)
 	}
 
-	err = gitops.AddFiles(ctx, td)
+	if err := gitops.StageChanges(ctx, td, added, removed); err != nil {
+		return fmt.Errorf("could not stage changes: %w", err)
+	}
+
+	hasChanges, err := gitops.HasStagedChanges(ctx, td)
 	if err != nil {
-		return fmt.Errorf("could not add generated files: %w", err)
+		return err
+	}
+	if !hasChanges {
+		fmt.Println("no changes to roll out")
+		return nil
 	}
 
 	commitMessage := fmt.Sprintf("rollout %s\n\n%s", commitTime, message)
-
-	err = gitops.CreateCommit(ctx, td, commitMessage)
-	if err != nil {
+	if err := gitops.CreateCommit(ctx, td, commitMessage); err != nil {
 		return fmt.Errorf("could not create commit: %w", err)
 	}
-
-	err = gitops.PushToOrigin(ctx, td, branchName)
-	if err != nil {
+	if err := gitops.PushToOrigin(ctx, td, branchName); err != nil {
 		return fmt.Errorf("could not push: %w", err)
 	}
 
@@ -66,9 +63,7 @@ func (g *GitHubRollout) RollOut(ctx context.Context, message string, generate fu
 	if err != nil {
 		return fmt.Errorf("could not create PR: %w", err)
 	}
-
 	fmt.Println(output)
-
 	return nil
 }
 

--- a/rollout/gitops/operations.go
+++ b/rollout/gitops/operations.go
@@ -36,19 +36,46 @@ func CreateBranch(ctx context.Context, dir string, branchName string) error {
 	return nil
 }
 
-func AddFiles(ctx context.Context, dir string) error {
-	cmd := exec.CommandContext(ctx, "git", "add", ".")
+// StageChanges runs `git add` for every added path and `git rm` for every
+// removed path. Paths must be relative to dir or absolute paths inside it. No
+// other paths are staged.
+func StageChanges(ctx context.Context, dir string, added, removed []string) error {
+	if len(added) > 0 {
+		args := append([]string{"add", "--"}, added...)
+		cmd := exec.CommandContext(ctx, "git", args...)
+		out := new(bytes.Buffer)
+		cmd.Stdout = out
+		cmd.Stderr = out
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("git add failed: %w\n%s", err, out.String())
+		}
+	}
+	if len(removed) > 0 {
+		args := append([]string{"rm", "--quiet", "--"}, removed...)
+		cmd := exec.CommandContext(ctx, "git", args...)
+		out := new(bytes.Buffer)
+		cmd.Stdout = out
+		cmd.Stderr = out
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("git rm failed: %w\n%s", err, out.String())
+		}
+	}
+	return nil
+}
+
+// HasStagedChanges reports whether any changes are staged in dir.
+func HasStagedChanges(ctx context.Context, dir string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--name-only")
 	out := new(bytes.Buffer)
 	cmd.Stdout = out
 	cmd.Stderr = out
 	cmd.Dir = dir
-
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("git add failed: %w\n%s", err, out.String())
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("git diff --cached failed: %w\n%s", err, out.String())
 	}
-
-	return nil
+	return out.Len() > 0, nil
 }
 
 func CreateCommit(ctx context.Context, dir string, message string) error {

--- a/rollout/ownership/ownership.go
+++ b/rollout/ownership/ownership.go
@@ -1,6 +1,9 @@
 package ownership
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"path/filepath"
 	"strings"
 )
@@ -26,4 +29,26 @@ func isJSON(path string) bool {
 // hasMarkerLine reports whether body starts with the YAML marker prefix.
 func hasMarkerLine(body []byte) bool {
 	return strings.HasPrefix(string(body), MarkerPrefix)
+}
+
+// StripMarker returns the portion of body that participates in the hash.
+// For YAML files with a marker line as the first line, the marker line and its
+// trailing newline are removed. All other inputs are returned unchanged.
+func StripMarker(path string, body []byte) []byte {
+	if !isYAML(path) || !hasMarkerLine(body) {
+		return body
+	}
+	nl := bytes.IndexByte(body, '\n')
+	if nl < 0 {
+		return nil
+	}
+	return body[nl+1:]
+}
+
+// ComputeBodyHash returns the lowercase-hex SHA-256 of the hash-relevant
+// portion of body (see StripMarker).
+func ComputeBodyHash(path string, body []byte) string {
+	stripped := StripMarker(path, body)
+	sum := sha256.Sum256(stripped)
+	return hex.EncodeToString(sum[:])
 }

--- a/rollout/ownership/ownership.go
+++ b/rollout/ownership/ownership.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -51,4 +53,38 @@ func ComputeBodyHash(path string, body []byte) string {
 	stripped := StripMarker(path, body)
 	sum := sha256.Sum256(stripped)
 	return hex.EncodeToString(sum[:])
+}
+
+// WriteMarked writes body to path and records monotool's ownership marker.
+// For YAML files, the marker is prepended as a comment line. For JSON files,
+// the marker is stored in a sidecar file named <path>+SidecarExt. Parent
+// directories are created as needed.
+func WriteMarked(path string, body []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+
+	hash := ComputeBodyHash(path, body)
+
+	switch {
+	case isYAML(path):
+		out := make([]byte, 0, len(MarkerPrefix)+len(hash)+1+len(body))
+		out = append(out, MarkerPrefix...)
+		out = append(out, hash...)
+		out = append(out, '\n')
+		out = append(out, body...)
+		if err := os.WriteFile(path, out, 0o666); err != nil {
+			return fmt.Errorf("write yaml %s: %w", path, err)
+		}
+	case isJSON(path):
+		if err := os.WriteFile(path, body, 0o666); err != nil {
+			return fmt.Errorf("write json %s: %w", path, err)
+		}
+		if err := os.WriteFile(path+SidecarExt, []byte(hash+"\n"), 0o666); err != nil {
+			return fmt.Errorf("write sidecar %s: %w", path+SidecarExt, err)
+		}
+	default:
+		return fmt.Errorf("WriteMarked: unsupported extension for %s", path)
+	}
+	return nil
 }

--- a/rollout/ownership/ownership.go
+++ b/rollout/ownership/ownership.go
@@ -172,3 +172,17 @@ func isHex64(s string) bool {
 	}
 	return true
 }
+
+// Remove deletes the file at path and, for JSON files, its sidecar. Missing
+// files are not an error.
+func Remove(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", path, err)
+	}
+	if isJSON(path) {
+		if err := os.Remove(path + SidecarExt); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove sidecar %s: %w", path+SidecarExt, err)
+		}
+	}
+	return nil
+}

--- a/rollout/ownership/ownership.go
+++ b/rollout/ownership/ownership.go
@@ -1,0 +1,29 @@
+package ownership
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// MarkerPrefix is the prefix of the YAML marker comment. The full line is
+// MarkerPrefix + <hex sha256> + "\n".
+const MarkerPrefix = "# monotool-hash: "
+
+// SidecarExt is appended to a JSON file path to form its marker sidecar path.
+const SidecarExt = ".monotool"
+
+// isYAML reports whether path has a YAML extension.
+func isYAML(path string) bool {
+	ext := filepath.Ext(path)
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// isJSON reports whether path has a JSON extension.
+func isJSON(path string) bool {
+	return filepath.Ext(path) == ".json"
+}
+
+// hasMarkerLine reports whether body starts with the YAML marker prefix.
+func hasMarkerLine(body []byte) bool {
+	return strings.HasPrefix(string(body), MarkerPrefix)
+}

--- a/rollout/ownership/ownership.go
+++ b/rollout/ownership/ownership.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -87,4 +88,87 @@ func WriteMarked(path string, body []byte) error {
 		return fmt.Errorf("WriteMarked: unsupported extension for %s", path)
 	}
 	return nil
+}
+
+// FileStatus describes a target path's ownership state.
+type FileStatus struct {
+	// Exists reports whether the file is present on disk.
+	Exists bool
+	// Owned reports whether a monotool marker is present (YAML header or JSON
+	// sidecar). False when Exists is false.
+	Owned bool
+	// Matches reports whether the recorded marker hash equals the current
+	// body's hash. False when Owned is false or when the marker is malformed.
+	Matches bool
+}
+
+// Status inspects path and returns its ownership status. A missing file
+// produces FileStatus{} (all false) with a nil error. I/O errors other than
+// "not exist" are returned.
+func Status(path string) (FileStatus, error) {
+	body, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return FileStatus{}, nil
+	}
+	if err != nil {
+		return FileStatus{}, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	st := FileStatus{Exists: true}
+
+	markerHash, owned, err := readMarker(path, body)
+	if err != nil {
+		return FileStatus{}, err
+	}
+	st.Owned = owned
+	if !owned {
+		return st, nil
+	}
+
+	if !isHex64(markerHash) {
+		return st, nil // owned but malformed → Matches stays false
+	}
+
+	st.Matches = ComputeBodyHash(path, body) == markerHash
+	return st, nil
+}
+
+// readMarker returns the recorded hash and whether a marker was found.
+// For YAML, the marker is the first-line comment. For JSON, the marker is the
+// sidecar file. body is the file body for YAML; for JSON it is unused.
+func readMarker(path string, body []byte) (hash string, owned bool, err error) {
+	switch {
+	case isYAML(path):
+		if !hasMarkerLine(body) {
+			return "", false, nil
+		}
+		nl := bytes.IndexByte(body, '\n')
+		if nl < 0 {
+			return "", true, nil
+		}
+		line := string(body[:nl])
+		return strings.TrimSpace(strings.TrimPrefix(line, MarkerPrefix)), true, nil
+	case isJSON(path):
+		side, err := os.ReadFile(path + SidecarExt)
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		if err != nil {
+			return "", false, fmt.Errorf("read sidecar %s: %w", path+SidecarExt, err)
+		}
+		return strings.TrimSpace(string(side)), true, nil
+	default:
+		return "", false, nil
+	}
+}
+
+// isHex64 reports whether s is exactly 64 lowercase hex characters.
+func isHex64(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	if _, err := hex.DecodeString(s); err != nil {
+		return false
+	}
+	return true
 }

--- a/rollout/ownership/ownership_test.go
+++ b/rollout/ownership/ownership_test.go
@@ -1,0 +1,54 @@
+package ownership
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestStripMarker(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		in   string
+		want string
+	}{
+		{"yaml without marker", "x.yaml", "apiVersion: v1\n", "apiVersion: v1\n"},
+		{"yaml with marker", "x.yaml", "# monotool-hash: abc\napiVersion: v1\n", "apiVersion: v1\n"},
+		{"yml with marker", "x.yml", "# monotool-hash: abc\nkind: X\n", "kind: X\n"},
+		{"json unchanged", "x.json", `{"a":1}` + "\n", `{"a":1}` + "\n"},
+		{"yaml only marker no body", "x.yaml", "# monotool-hash: abc\n", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripMarker(tc.path, []byte(tc.in))
+			if string(got) != tc.want {
+				t.Fatalf("StripMarker(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeBodyHash(t *testing.T) {
+	body := []byte("apiVersion: v1\nkind: ConfigMap\n")
+	sum := sha256.Sum256(body)
+	want := hex.EncodeToString(sum[:])
+
+	// YAML with no marker: hash is over the whole input.
+	gotYAML := ComputeBodyHash("x.yaml", body)
+	if gotYAML != want {
+		t.Fatalf("YAML no-marker hash = %s, want %s", gotYAML, want)
+	}
+
+	// YAML with marker: hash is over the body after the marker.
+	gotMarked := ComputeBodyHash("x.yaml", append([]byte("# monotool-hash: deadbeef\n"), body...))
+	if gotMarked != want {
+		t.Fatalf("YAML marked hash = %s, want %s", gotMarked, want)
+	}
+
+	// JSON: hash is over the entire file body (no marker possible inline).
+	gotJSON := ComputeBodyHash("x.json", body)
+	if gotJSON != want {
+		t.Fatalf("JSON hash = %s, want %s", gotJSON, want)
+	}
+}

--- a/rollout/ownership/ownership_test.go
+++ b/rollout/ownership/ownership_test.go
@@ -116,3 +116,131 @@ func TestWriteMarkedCreatesDirs(t *testing.T) {
 		t.Fatalf("Stat: %v", err)
 	}
 }
+
+func TestStatusOwnedAndUnmodified(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ok.yaml")
+	body := []byte("kind: X\n")
+	if err := WriteMarked(path, body); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Owned {
+		t.Fatal("expected Owned=true")
+	}
+	if !st.Matches {
+		t.Fatal("expected Matches=true")
+	}
+}
+
+func TestStatusUnmarkedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.yaml")
+	if err := os.WriteFile(path, []byte("kind: X\n"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Owned {
+		t.Fatal("expected Owned=false")
+	}
+}
+
+func TestStatusHashMismatchYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.yaml")
+	if err := WriteMarked(path, []byte("a: 1\n")); err != nil {
+		t.Fatal(err)
+	}
+	// Tamper with the body while leaving the marker line intact.
+	cur, _ := os.ReadFile(path)
+	tampered := append([]byte{}, cur...)
+	tampered = append(tampered, []byte("extra: true\n")...)
+	if err := os.WriteFile(path, tampered, 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Owned {
+		t.Fatal("expected Owned=true (marker still present)")
+	}
+	if st.Matches {
+		t.Fatal("expected Matches=false (body tampered)")
+	}
+}
+
+func TestStatusUnmarkedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.json")
+	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Owned {
+		t.Fatal("expected Owned=false (no sidecar)")
+	}
+}
+
+func TestStatusHashMismatchJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.json")
+	if err := WriteMarked(path, []byte(`{"a":1}`+"\n")); err != nil {
+		t.Fatal(err)
+	}
+	// Tamper with the JSON, leave sidecar alone.
+	if err := os.WriteFile(path, []byte(`{"a":2}`+"\n"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Owned {
+		t.Fatal("expected Owned=true (sidecar present)")
+	}
+	if st.Matches {
+		t.Fatal("expected Matches=false (body tampered)")
+	}
+}
+
+func TestStatusMalformedMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.yaml")
+	// Marker prefix is present but the hash is not valid hex.
+	body := []byte(MarkerPrefix + "not-a-real-hash-value\nkind: X\n")
+	if err := os.WriteFile(path, body, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Status(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Owned {
+		t.Fatal("expected Owned=true (marker prefix present)")
+	}
+	if st.Matches {
+		t.Fatal("expected Matches=false (malformed marker counts as mismatch)")
+	}
+}
+
+func TestStatusMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	st, err := Status(filepath.Join(dir, "gone.yaml"))
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.Exists {
+		t.Fatal("expected Exists=false")
+	}
+}

--- a/rollout/ownership/ownership_test.go
+++ b/rollout/ownership/ownership_test.go
@@ -3,6 +3,8 @@ package ownership
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -50,5 +52,67 @@ func TestComputeBodyHash(t *testing.T) {
 	gotJSON := ComputeBodyHash("x.json", body)
 	if gotJSON != want {
 		t.Fatalf("JSON hash = %s, want %s", gotJSON, want)
+	}
+}
+
+func TestWriteMarkedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deploy.yaml")
+	body := []byte("apiVersion: apps/v1\nkind: Deployment\n")
+
+	if err := WriteMarked(path, body); err != nil {
+		t.Fatalf("WriteMarked: %v", err)
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	wantHash := ComputeBodyHash(path, body)
+	wantHead := MarkerPrefix + wantHash + "\n"
+	if string(written[:len(wantHead)]) != wantHead {
+		t.Fatalf("file head = %q, want %q", written[:len(wantHead)], wantHead)
+	}
+	if string(written[len(wantHead):]) != string(body) {
+		t.Fatalf("file body after marker = %q, want %q", written[len(wantHead):], body)
+	}
+}
+
+func TestWriteMarkedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	body := []byte(`{"a":1}` + "\n")
+
+	if err := WriteMarked(path, body); err != nil {
+		t.Fatalf("WriteMarked: %v", err)
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile json: %v", err)
+	}
+	if string(written) != string(body) {
+		t.Fatalf("JSON body modified: got %q, want %q", written, body)
+	}
+
+	sidecar, err := os.ReadFile(path + SidecarExt)
+	if err != nil {
+		t.Fatalf("ReadFile sidecar: %v", err)
+	}
+	wantHash := ComputeBodyHash(path, body)
+	if string(sidecar) != wantHash+"\n" {
+		t.Fatalf("sidecar = %q, want %q", sidecar, wantHash+"\n")
+	}
+}
+
+func TestWriteMarkedCreatesDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested/dir/x.yaml")
+	if err := WriteMarked(path, []byte("a: b\n")); err != nil {
+		t.Fatalf("WriteMarked nested: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Stat: %v", err)
 	}
 }

--- a/rollout/ownership/ownership_test.go
+++ b/rollout/ownership/ownership_test.go
@@ -244,3 +244,41 @@ func TestStatusMissingFile(t *testing.T) {
 		t.Fatal("expected Exists=false")
 	}
 }
+
+func TestRemoveYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.yaml")
+	if err := WriteMarked(path, []byte("a: 1\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := Remove(path); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("expected file removed")
+	}
+}
+
+func TestRemoveJSONIncludesSidecar(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.json")
+	if err := WriteMarked(path, []byte(`{"a":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := Remove(path); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("expected JSON removed")
+	}
+	if _, err := os.Stat(path + SidecarExt); !os.IsNotExist(err) {
+		t.Fatal("expected sidecar removed")
+	}
+}
+
+func TestRemoveMissingIsNoError(t *testing.T) {
+	dir := t.TempDir()
+	if err := Remove(filepath.Join(dir, "gone.yaml")); err != nil {
+		t.Fatalf("Remove missing: %v", err)
+	}
+}

--- a/rollout/rollout.go
+++ b/rollout/rollout.go
@@ -141,8 +141,7 @@ func renderTemplate(path string, raw []byte, values map[string]any) ([]byte, err
 	return buf.Bytes(), nil
 }
 
-// RollOut runs a full rollout. The old removeOldManifests + write-everything
-// logic is being replaced incrementally; the next task wires the new prune in.
+// RollOut runs a full rollout.
 func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[string]any, message string, force bool) error {
 	if r.Gitea == nil && r.GitHub == nil {
 		return errors.New("rollout must have either a gitea or github config")
@@ -157,7 +156,7 @@ func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[st
 	}
 
 	generate := func(workDir string) (added, removed []string, err error) {
-		written, conflicts, err := GenerateManifests(ctx, GenerateOpts{
+		written, writeConflicts, err := GenerateManifests(ctx, GenerateOpts{
 			TemplatesPath: templatesAbs,
 			WorkDir:       workDir,
 			TargetPath:    r.TargetPath,
@@ -165,17 +164,39 @@ func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[st
 			Force:         force,
 		})
 		if err != nil {
-			return written, nil, err
+			return nil, nil, err
 		}
-		if !conflicts.Empty() {
-			conflicts.Report(os.Stderr)
+
+		var pruneConflicts *conflict.Set
+		if r.PruneTargets {
+			desired := make(map[string]struct{}, len(written))
+			for _, p := range written {
+				desired[p] = struct{}{}
+			}
+			var pruned []string
+			pruned, pruneConflicts, err = Prune(ctx, PruneOpts{
+				WorkDir:    workDir,
+				TargetPath: r.TargetPath,
+				DesiredAbs: desired,
+				Force:      force,
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+			removed = pruned
+		} else {
+			pruneConflicts = conflict.New()
+		}
+
+		all := mergeConflicts(writeConflicts, pruneConflicts)
+		if !all.Empty() {
+			all.Report(os.Stderr)
 			if !force {
-				return nil, nil, conflicts.Err()
+				return nil, nil, all.Err()
 			}
 		}
 
-		// Pruning is wired in the next task. For now: no removed paths.
-		return written, nil, nil
+		return written, removed, nil
 	}
 
 	switch {
@@ -189,4 +210,153 @@ func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[st
 		}
 	}
 	return nil
+}
+
+// PruneOpts drives Prune. DesiredAbs is the set of absolute paths Prune must
+// leave alone (typically: every path GenerateManifests wrote, including
+// sidecars).
+type PruneOpts struct {
+	WorkDir    string
+	TargetPath string
+	DesiredAbs map[string]struct{}
+	Force      bool
+}
+
+// Prune walks WorkDir/TargetPath and deletes monotool-owned files that are no
+// longer in DesiredAbs, returning the absolute paths it removed and any
+// conflicts it detected. Unowned files (no marker) are left alone. Owned files
+// whose body hash no longer matches their marker generate a hash-mismatch
+// conflict; without Force they are not deleted, with Force they are reported
+// but still not deleted (we never delete a file a human edited).
+func Prune(_ context.Context, opts PruneOpts) (removed []string, conflicts *conflict.Set, err error) {
+	conflicts = conflict.New()
+	root := filepath.Join(opts.WorkDir, opts.TargetPath)
+
+	if _, statErr := os.Stat(root); errors.Is(statErr, os.ErrNotExist) {
+		return nil, conflicts, nil
+	}
+
+	type ownedFile struct {
+		path string
+		rel  string
+	}
+	var ownedFiles []ownedFile
+	var orphanSidecars []string
+
+	err = filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		// Orphan sidecar (sidecar whose JSON sibling doesn't exist) → cruft.
+		if filepath.Ext(p) == ownership.SidecarExt {
+			jsonPath := p[:len(p)-len(ownership.SidecarExt)]
+			if _, statErr := os.Stat(jsonPath); errors.Is(statErr, os.ErrNotExist) {
+				orphanSidecars = append(orphanSidecars, p)
+			}
+			return nil
+		}
+
+		st, err := ownership.Status(p)
+		if err != nil {
+			return err
+		}
+		if !st.Owned {
+			return nil
+		}
+		rel, err := filepath.Rel(opts.WorkDir, p)
+		if err != nil {
+			return err
+		}
+		ownedFiles = append(ownedFiles, ownedFile{path: p, rel: rel})
+		return nil
+	})
+	if err != nil {
+		return nil, conflicts, fmt.Errorf("walk %s: %w", root, err)
+	}
+
+	for _, o := range ownedFiles {
+		if _, keep := opts.DesiredAbs[o.path]; keep {
+			continue
+		}
+
+		st, err := ownership.Status(o.path)
+		if err != nil {
+			return removed, conflicts, err
+		}
+		if !st.Matches {
+			conflicts.Add(o.rel, conflict.ReasonHashMismatch)
+			continue // never delete a file the human edited
+		}
+		if err := ownership.Remove(o.path); err != nil {
+			return removed, conflicts, err
+		}
+		removed = append(removed, o.path)
+		if filepath.Ext(o.path) == ".json" {
+			removed = append(removed, o.path+ownership.SidecarExt)
+		}
+	}
+
+	for _, p := range orphanSidecars {
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return removed, conflicts, err
+		}
+		removed = append(removed, p)
+	}
+
+	if err := removeEmptyDirs(root); err != nil {
+		return removed, conflicts, err
+	}
+	return removed, conflicts, nil
+}
+
+// removeEmptyDirs walks root bottom-up and removes any directory left empty.
+// root itself is not removed.
+func removeEmptyDirs(root string) error {
+	var dirs []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			dirs = append(dirs, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	// Process deepest-first.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		if dirs[i] == root {
+			continue
+		}
+		entries, err := os.ReadDir(dirs[i])
+		if err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			if err := os.Remove(dirs[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func mergeConflicts(a, b *conflict.Set) *conflict.Set {
+	out := conflict.New()
+	for _, c := range a.Items() {
+		out.Add(c.Path, c.Reason)
+	}
+	for _, c := range b.Items() {
+		out.Add(c.Path, c.Reason)
+	}
+	return out
 }

--- a/rollout/rollout.go
+++ b/rollout/rollout.go
@@ -1,18 +1,19 @@
 package rollout
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/draganm/manifestor/interpolate"
+	"github.com/draganm/monotool/rollout/conflict"
 	"github.com/draganm/monotool/rollout/gitea"
 	"github.com/draganm/monotool/rollout/github"
+	"github.com/draganm/monotool/rollout/ownership"
 	"gopkg.in/yaml.v3"
 )
 
@@ -24,151 +25,168 @@ type Rollout struct {
 	PruneTargets bool                  `yaml:"pruneTargets"`
 }
 
-func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[string]any, message string) error {
+// GenerateOpts is the input to GenerateManifests. It is exposed (and the
+// function is exported) so tests can drive the write phase without needing a
+// git remote.
+type GenerateOpts struct {
+	TemplatesPath string
+	WorkDir       string
+	TargetPath    string
+	Values        map[string]any
+	Force         bool
+}
+
+// GenerateManifests reads templates, interpolates them, and writes the
+// resulting YAML/JSON files into WorkDir/TargetPath using ownership markers.
+// It returns the absolute paths of every file it wrote (including JSON
+// sidecars) and the set of conflicts it detected. If Force is true, conflicts
+// are recorded but writes proceed anyway.
+func GenerateManifests(_ context.Context, opts GenerateOpts) (written []string, conflicts *conflict.Set, err error) {
+	conflicts = conflict.New()
+
+	templates, err := readTemplates(opts.TemplatesPath, opts.TargetPath)
+	if err != nil {
+		return nil, conflicts, err
+	}
+
+	for relPath, raw := range templates {
+		fullPath := filepath.Join(opts.WorkDir, relPath)
+
+		body, err := renderTemplate(fullPath, raw, opts.Values)
+		if err != nil {
+			return written, conflicts, fmt.Errorf("render %s: %w", relPath, err)
+		}
+
+		st, err := ownership.Status(fullPath)
+		if err != nil {
+			return written, conflicts, fmt.Errorf("status %s: %w", fullPath, err)
+		}
+
+		if st.Exists && (!st.Owned || !st.Matches) {
+			reason := conflict.ReasonUnmarked
+			if st.Owned {
+				reason = conflict.ReasonHashMismatch
+			}
+			conflicts.Add(relPath, reason)
+			if !opts.Force {
+				continue
+			}
+		}
+
+		if err := ownership.WriteMarked(fullPath, body); err != nil {
+			return written, conflicts, err
+		}
+		written = append(written, fullPath)
+		if filepath.Ext(fullPath) == ".json" {
+			written = append(written, fullPath+ownership.SidecarExt)
+		}
+	}
+
+	return written, conflicts, nil
+}
+
+// readTemplates walks templatesPath, returning a map keyed by the target-path-
+// relative path (e.g., "apps/staging/deploy.yaml") with the raw template body.
+// Non-YAML/JSON files and directories are skipped.
+func readTemplates(templatesPath, targetPath string) (map[string][]byte, error) {
+	absRoot, err := filepath.Abs(templatesPath)
+	if err != nil {
+		return nil, fmt.Errorf("abs %s: %w", templatesPath, err)
+	}
+
+	out := map[string][]byte{}
+	err = filepath.WalkDir(absRoot, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		ext := filepath.Ext(p)
+		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+			return nil
+		}
+		rel, err := filepath.Rel(absRoot, p)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("read template %s: %w", p, err)
+		}
+		out[filepath.Join(targetPath, rel)] = data
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk templates: %w", err)
+	}
+	return out, nil
+}
+
+// renderTemplate interpolates a template body using values. JSON files are
+// copied verbatim (matching pre-existing monotool behavior). YAML files are
+// run through manifestor's interpolator and re-encoded.
+func renderTemplate(path string, raw []byte, values map[string]any) ([]byte, error) {
+	if filepath.Ext(path) == ".json" {
+		return raw, nil
+	}
+	buf := new(bytes.Buffer)
+	enc := yaml.NewEncoder(buf)
+	if err := interpolate.Interpolate(string(raw), "", values, enc); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// RollOut runs a full rollout. The old removeOldManifests + write-everything
+// logic is being replaced incrementally; the next task wires the new prune in.
+func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[string]any, message string, force bool) error {
 	if r.Gitea == nil && r.GitHub == nil {
 		return errors.New("rollout must have either a gitea or github config")
 	}
-
 	if r.Gitea != nil && r.GitHub != nil {
 		return errors.New("rollout cannot have both gitea and github configs")
 	}
 
-	templatesPath, err := filepath.Abs(filepath.Join(projectRoot, r.Templates))
+	templatesAbs, err := filepath.Abs(filepath.Join(projectRoot, r.Templates))
 	if err != nil {
 		return fmt.Errorf("could not get absolute path for the deployment templates: %w", err)
 	}
 
-	templates := map[string][]byte{}
-
-	allDirs := []string{}
-
-	err = filepath.WalkDir(templatesPath, func(path string, d fs.DirEntry, err error) error {
+	generate := func(workDir string) (added, removed []string, err error) {
+		written, conflicts, err := GenerateManifests(ctx, GenerateOpts{
+			TemplatesPath: templatesAbs,
+			WorkDir:       workDir,
+			TargetPath:    r.TargetPath,
+			Values:        values,
+			Force:         force,
+		})
 		if err != nil {
-			return err
+			return written, nil, err
 		}
-
-		if d.IsDir() {
-			relativePath, err := filepath.Rel(templatesPath, path)
-			if err != nil {
-				return fmt.Errorf("could not get relative path of %s: %w", path, err)
-			}
-
-			if relativePath != "." {
-				allDirs = append(allDirs, relativePath)
+		if !conflicts.Empty() {
+			conflicts.Report(os.Stderr)
+			if !force {
+				return nil, nil, conflicts.Err()
 			}
 		}
 
-		if !d.Type().IsRegular() {
-			return nil
-		}
-
-		ext := filepath.Ext(path)
-		if !(ext == ".yaml" || ext == ".yml" || ext == ".json") {
-			return nil
-		}
-
-		relativePath, err := filepath.Rel(templatesPath, path)
-		if err != nil {
-			return fmt.Errorf("could not get relative path of %s: %w", path, err)
-		}
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("could not read %s: %w", path, err)
-		}
-
-		templates[filepath.Join(r.TargetPath, relativePath)] = data
-
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("could not read templates: %w", err)
-	}
-
-	removeOldManifests := func(dir string) error {
-
-		if !r.PruneTargets || len(allDirs) == 0 {
-			return nil
-		}
-
-		prev := allDirs[0]
-
-		toRemove := []string{
-			filepath.Join(dir, prev),
-		}
-
-		for _, d := range allDirs[1:] {
-			if strings.HasPrefix(d, prev) {
-				continue
-			}
-			toRemove = append(toRemove, filepath.Join(dir, d))
-			prev = d
-		}
-
-		for _, d := range toRemove {
-			os.RemoveAll(d)
-		}
-
-		return nil
-	}
-
-	generateManifests := func(dir string) error {
-		err = removeOldManifests(dir)
-		if err != nil {
-			return fmt.Errorf("could not remove old manifests: %w", err)
-		}
-
-		for n, d := range templates {
-			manifestPath := filepath.Join(dir, n)
-
-			err := os.MkdirAll(path.Dir(manifestPath), 0777)
-			if err != nil {
-				return fmt.Errorf("could not mkdir %s: %w", path.Dir(manifestPath), err)
-			}
-
-			f, err := os.OpenFile(manifestPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
-			if err != nil {
-				return fmt.Errorf("could not open manifest output file %s: %w", manifestPath, err)
-			}
-
-			if filepath.Ext(manifestPath) == ".json" {
-				_, err = f.Write(d)
-				if err != nil {
-					f.Close()
-					return fmt.Errorf("could not write %s: %w", manifestPath, err)
-				}
-			} else {
-				enc := yaml.NewEncoder(f)
-				err = interpolate.Interpolate(string(d), "", values, enc)
-				if err != nil {
-					f.Close()
-					return fmt.Errorf("could not interpolate %s: %w", manifestPath, err)
-				}
-			}
-
-			err = f.Close()
-			if err != nil {
-				return fmt.Errorf("could not close %s: %w", manifestPath, err)
-			}
-		}
-
-		return nil
+		// Pruning is wired in the next task. For now: no removed paths.
+		return written, nil, nil
 	}
 
 	switch {
 	case r.Gitea != nil:
-		err = r.Gitea.RollOut(ctx, message, generateManifests)
-		if err != nil {
+		if err := r.Gitea.RollOut(ctx, message, generate); err != nil {
 			return fmt.Errorf("gitea deployment failed: %w", err)
 		}
 	case r.GitHub != nil:
-		err = r.GitHub.RollOut(ctx, message, generateManifests)
-		if err != nil {
+		if err := r.GitHub.RollOut(ctx, message, generate); err != nil {
 			return fmt.Errorf("github deployment failed: %w", err)
 		}
 	}
-
 	return nil
-
 }

--- a/rollout/rollout.go
+++ b/rollout/rollout.go
@@ -158,7 +158,7 @@ func renderTemplate(path string, raw []byte, values map[string]any) ([]byte, err
 }
 
 // RollOut runs a full rollout.
-func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[string]any, message string, force bool) error {
+func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[string]any, message string, force bool, conf confirm.Confirmer) error {
 	if r.Gitea == nil && r.GitHub == nil {
 		return errors.New("rollout must have either a gitea or github config")
 	}
@@ -178,6 +178,7 @@ func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[st
 			TargetPath:    r.TargetPath,
 			Values:        values,
 			Force:         force,
+			Confirm:       conf,
 		})
 		if err != nil {
 			return nil, nil, err
@@ -195,6 +196,7 @@ func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[st
 				TargetPath: r.TargetPath,
 				DesiredAbs: desired,
 				Force:      force,
+				Confirm:    conf,
 			})
 			if err != nil {
 				return nil, nil, err
@@ -206,12 +208,15 @@ func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[st
 
 		all := mergeConflicts(writeConflicts, pruneConflicts)
 		if !all.Empty() {
-			if force {
-				all.Warn(os.Stderr)
-			} else {
+			switch {
+			case !force:
 				all.Report(os.Stderr)
 				return nil, nil, all.Err()
+			case conf == nil:
+				// --force without a Confirmer: legacy unconditional behavior
+				all.Warn(os.Stderr)
 			}
+			// --force with a Confirmer: each prompt was its own ack, no extra output
 		}
 
 		return written, removed, nil

--- a/rollout/rollout.go
+++ b/rollout/rollout.go
@@ -238,6 +238,10 @@ type PruneOpts struct {
 	TargetPath string
 	DesiredAbs map[string]struct{}
 	Force      bool
+	// Confirm, when non-nil, is invoked before each deletion (stale owned
+	// file or orphan sidecar). Returning proceed=false skips that deletion;
+	// returning a non-nil error aborts Prune.
+	Confirm confirm.Confirmer
 }
 
 // Prune walks WorkDir/TargetPath and deletes monotool-owned files that are no
@@ -309,6 +313,15 @@ func Prune(_ context.Context, opts PruneOpts) (removed []string, conflicts *conf
 			conflicts.Add(o.rel, conflict.ReasonHashMismatch)
 			continue // never delete a file the human edited
 		}
+		if opts.Confirm != nil {
+			proceed, err := opts.Confirm("delete stale", o.rel)
+			if err != nil {
+				return removed, conflicts, err
+			}
+			if !proceed {
+				continue
+			}
+		}
 		if err := ownership.Remove(o.path); err != nil {
 			return removed, conflicts, err
 		}
@@ -319,6 +332,19 @@ func Prune(_ context.Context, opts PruneOpts) (removed []string, conflicts *conf
 	}
 
 	for _, p := range orphanSidecars {
+		if opts.Confirm != nil {
+			rel, relErr := filepath.Rel(opts.WorkDir, p)
+			if relErr != nil {
+				return removed, conflicts, relErr
+			}
+			proceed, err := opts.Confirm("remove orphan sidecar", rel)
+			if err != nil {
+				return removed, conflicts, err
+			}
+			if !proceed {
+				continue
+			}
+		}
 		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return removed, conflicts, err
 		}

--- a/rollout/rollout.go
+++ b/rollout/rollout.go
@@ -190,8 +190,10 @@ func (r *Rollout) RollOut(ctx context.Context, projectRoot string, values map[st
 
 		all := mergeConflicts(writeConflicts, pruneConflicts)
 		if !all.Empty() {
-			all.Report(os.Stderr)
-			if !force {
+			if force {
+				all.Warn(os.Stderr)
+			} else {
+				all.Report(os.Stderr)
 				return nil, nil, all.Err()
 			}
 		}

--- a/rollout/rollout.go
+++ b/rollout/rollout.go
@@ -239,6 +239,7 @@ func Prune(_ context.Context, opts PruneOpts) (removed []string, conflicts *conf
 	type ownedFile struct {
 		path string
 		rel  string
+		st   ownership.FileStatus
 	}
 	var ownedFiles []ownedFile
 	var orphanSidecars []string
@@ -274,7 +275,7 @@ func Prune(_ context.Context, opts PruneOpts) (removed []string, conflicts *conf
 		if err != nil {
 			return err
 		}
-		ownedFiles = append(ownedFiles, ownedFile{path: p, rel: rel})
+		ownedFiles = append(ownedFiles, ownedFile{path: p, rel: rel, st: st})
 		return nil
 	})
 	if err != nil {
@@ -286,11 +287,7 @@ func Prune(_ context.Context, opts PruneOpts) (removed []string, conflicts *conf
 			continue
 		}
 
-		st, err := ownership.Status(o.path)
-		if err != nil {
-			return removed, conflicts, err
-		}
-		if !st.Matches {
+		if !o.st.Matches {
 			conflicts.Add(o.rel, conflict.ReasonHashMismatch)
 			continue // never delete a file the human edited
 		}

--- a/rollout/rollout.go
+++ b/rollout/rollout.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/draganm/manifestor/interpolate"
+	"github.com/draganm/monotool/rollout/confirm"
 	"github.com/draganm/monotool/rollout/conflict"
 	"github.com/draganm/monotool/rollout/gitea"
 	"github.com/draganm/monotool/rollout/github"
@@ -34,6 +35,10 @@ type GenerateOpts struct {
 	TargetPath    string
 	Values        map[string]any
 	Force         bool
+	// Confirm, when non-nil, is invoked before each overwrite-on-conflict
+	// write under --force. Returning proceed=false skips the write; returning
+	// a non-nil error aborts GenerateManifests.
+	Confirm confirm.Confirmer
 }
 
 // GenerateManifests reads templates, interpolates them, and writes the
@@ -64,12 +69,23 @@ func GenerateManifests(_ context.Context, opts GenerateOpts) (written []string, 
 
 		if st.Exists && (!st.Owned || !st.Matches) {
 			reason := conflict.ReasonUnmarked
+			action := "overwrite unmarked"
 			if st.Owned {
 				reason = conflict.ReasonHashMismatch
+				action = "overwrite edited"
 			}
 			conflicts.Add(relPath, reason)
 			if !opts.Force {
 				continue
+			}
+			if opts.Confirm != nil {
+				proceed, err := opts.Confirm(action, relPath)
+				if err != nil {
+					return written, conflicts, err
+				}
+				if !proceed {
+					continue
+				}
 			}
 		}
 

--- a/rollout/rollout_test.go
+++ b/rollout/rollout_test.go
@@ -407,3 +407,112 @@ func TestGenerateManifestsConfirmAbort(t *testing.T) {
 		t.Fatalf("err = %v, want ErrAborted", err)
 	}
 }
+
+func TestPruneConfirmYes(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	stale := filepath.Join(targetDir, "stale.yaml")
+	mustWriteMarked(t, stale, "kind: Stale\n")
+
+	var calls []string
+	conf := func(action, path string) (bool, error) {
+		calls = append(calls, action+":"+path)
+		return true, nil
+	}
+
+	removed, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Confirm:    conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 || calls[0] != "delete stale:apps/staging/stale.yaml" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if len(removed) != 1 || removed[0] != stale {
+		t.Fatalf("removed = %v, want [%s]", removed, stale)
+	}
+}
+
+func TestPruneConfirmNo(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	stale := filepath.Join(targetDir, "stale.yaml")
+	mustWriteMarked(t, stale, "kind: Stale\n")
+
+	conf := func(action, path string) (bool, error) {
+		return false, nil
+	}
+
+	removed, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Confirm:    conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want empty", removed)
+	}
+	if _, err := os.Stat(stale); err != nil {
+		t.Fatalf("stale file was deleted: %v", err)
+	}
+}
+
+func TestPruneConfirmAbort(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	stale := filepath.Join(targetDir, "stale.yaml")
+	mustWriteMarked(t, stale, "kind: Stale\n")
+
+	conf := func(action, path string) (bool, error) {
+		return false, confirm.ErrAborted
+	}
+
+	_, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Confirm:    conf,
+	})
+	if !errors.Is(err, confirm.ErrAborted) {
+		t.Fatalf("err = %v, want ErrAborted", err)
+	}
+}
+
+func TestPruneOrphanSidecarConfirmNo(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	sidecar := filepath.Join(targetDir, "ghost.json.monotool")
+	mustWrite(t, sidecar, "deadbeef\n")
+
+	var calls []string
+	conf := func(action, path string) (bool, error) {
+		calls = append(calls, action+":"+path)
+		return false, nil
+	}
+
+	removed, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Confirm:    conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 || calls[0] != "remove orphan sidecar:apps/staging/ghost.json.monotool" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want empty", removed)
+	}
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("sidecar was deleted: %v", err)
+	}
+}

--- a/rollout/rollout_test.go
+++ b/rollout/rollout_test.go
@@ -1,0 +1,127 @@
+package rollout
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/draganm/monotool/rollout/conflict"
+)
+
+// helpers
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o666); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupTemplates(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		mustWrite(t, filepath.Join(dir, name), body)
+	}
+	return dir
+}
+
+func TestGenerateManifestsFirstWrite(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "apiVersion: apps/v1\nkind: Deployment\n",
+		"data.json":   `{"a":1}` + "\n",
+	})
+	workDir := t.TempDir()
+
+	written, conflicts, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifests: %v", err)
+	}
+	if !conflicts.Empty() {
+		t.Fatalf("expected no conflicts, got %d", len(conflicts.Items()))
+	}
+
+	sort.Strings(written)
+	want := []string{
+		filepath.Join(workDir, "apps/staging/data.json"),
+		filepath.Join(workDir, "apps/staging/data.json.monotool"),
+		filepath.Join(workDir, "apps/staging/deploy.yaml"),
+	}
+	if !equalSlices(written, want) {
+		t.Fatalf("written = %v, want %v", written, want)
+	}
+}
+
+func TestGenerateManifestsRefusesUnmarked(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	mustWrite(t, filepath.Join(workDir, "apps/staging/deploy.yaml"), "kind: HumanlyEdited\n")
+
+	_, conflicts, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifests: %v", err)
+	}
+	if conflicts.Empty() {
+		t.Fatal("expected conflicts, got none")
+	}
+	got := conflicts.Items()
+	if len(got) != 1 || got[0].Reason != conflict.ReasonUnmarked {
+		t.Fatalf("expected one unmarked conflict, got %+v", got)
+	}
+}
+
+func TestGenerateManifestsForceOverwritesUnmarked(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	target := filepath.Join(workDir, "apps/staging/deploy.yaml")
+	mustWrite(t, target, "kind: HumanlyEdited\n")
+
+	written, _, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+		Force:         true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) != 1 || written[0] != target {
+		t.Fatalf("written = %v, want [%s]", written, target)
+	}
+	body, _ := os.ReadFile(target)
+	if !strings.Contains(string(body), "kind: Deployment") {
+		t.Fatalf("file was not overwritten: %s", body)
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/rollout/rollout_test.go
+++ b/rollout/rollout_test.go
@@ -2,12 +2,14 @@ package rollout
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
 
+	"github.com/draganm/monotool/rollout/confirm"
 	"github.com/draganm/monotool/rollout/conflict"
 	"github.com/draganm/monotool/rollout/ownership"
 )
@@ -310,5 +312,98 @@ func mustWriteMarked(t *testing.T, path, body string) {
 	}
 	if err := ownership.WriteMarked(path, []byte(body)); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGenerateManifestsConfirmYes(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	target := filepath.Join(workDir, "apps/staging/deploy.yaml")
+	mustWrite(t, target, "kind: HumanlyEdited\n")
+
+	var calls []string
+	conf := func(action, path string) (bool, error) {
+		calls = append(calls, action+":"+path)
+		return true, nil
+	}
+
+	written, _, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+		Force:         true,
+		Confirm:       conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 || calls[0] != "overwrite unmarked:apps/staging/deploy.yaml" {
+		t.Fatalf("calls = %v", calls)
+	}
+	if len(written) != 1 || written[0] != target {
+		t.Fatalf("written = %v, want [%s]", written, target)
+	}
+	body, _ := os.ReadFile(target)
+	if !strings.Contains(string(body), "kind: Deployment") {
+		t.Fatalf("file not overwritten: %s", body)
+	}
+}
+
+func TestGenerateManifestsConfirmNo(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	target := filepath.Join(workDir, "apps/staging/deploy.yaml")
+	mustWrite(t, target, "kind: HumanlyEdited\n")
+
+	conf := func(action, path string) (bool, error) {
+		return false, nil
+	}
+
+	written, _, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+		Force:         true,
+		Confirm:       conf,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(written) != 0 {
+		t.Fatalf("written = %v, want empty", written)
+	}
+	body, _ := os.ReadFile(target)
+	if string(body) != "kind: HumanlyEdited\n" {
+		t.Fatalf("file was modified, body = %q", body)
+	}
+}
+
+func TestGenerateManifestsConfirmAbort(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	mustWrite(t, filepath.Join(workDir, "apps/staging/deploy.yaml"), "kind: HumanlyEdited\n")
+
+	conf := func(action, path string) (bool, error) {
+		return false, confirm.ErrAborted
+	}
+
+	_, _, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+		Force:         true,
+		Confirm:       conf,
+	})
+	if !errors.Is(err, confirm.ErrAborted) {
+		t.Fatalf("err = %v, want ErrAborted", err)
 	}
 }

--- a/rollout/rollout_test.go
+++ b/rollout/rollout_test.go
@@ -88,6 +88,35 @@ func TestGenerateManifestsRefusesUnmarked(t *testing.T) {
 	}
 }
 
+func TestGenerateManifestsDetectsHashMismatch(t *testing.T) {
+	templatesDir := setupTemplates(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	})
+	workDir := t.TempDir()
+	target := filepath.Join(workDir, "apps/staging/deploy.yaml")
+	mustWriteMarked(t, target, "kind: Deployment\n")
+
+	// Tamper with the body, keep the marker line intact.
+	cur, _ := os.ReadFile(target)
+	if err := os.WriteFile(target, append(cur, []byte("extra: true\n")...), 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	_, conflicts, err := GenerateManifests(context.Background(), GenerateOpts{
+		TemplatesPath: templatesDir,
+		WorkDir:       workDir,
+		TargetPath:    "apps/staging",
+		Values:        map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateManifests: %v", err)
+	}
+	got := conflicts.Items()
+	if len(got) != 1 || got[0].Reason != conflict.ReasonHashMismatch {
+		t.Fatalf("expected one hash-mismatch conflict, got %+v", got)
+	}
+}
+
 func TestGenerateManifestsForceOverwritesUnmarked(t *testing.T) {
 	templatesDir := setupTemplates(t, map[string]string{
 		"deploy.yaml": "kind: Deployment\n",

--- a/rollout/rollout_test.go
+++ b/rollout/rollout_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/draganm/monotool/rollout/conflict"
+	"github.com/draganm/monotool/rollout/ownership"
 )
 
 // helpers
@@ -124,4 +125,161 @@ func equalSlices(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestPruneRemovesStaleOwnedFile(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+
+	// Pretend last rollout wrote two files.
+	staleYAML := filepath.Join(targetDir, "stale.yaml")
+	staleJSON := filepath.Join(targetDir, "stale.json")
+	mustWriteMarked(t, staleYAML, "kind: Stale\n")
+	mustWriteMarked(t, staleJSON, `{"old":true}`+"\n")
+
+	desired := map[string]struct{}{
+		filepath.Join(targetDir, "current.yaml"): {},
+	}
+
+	removed, conflicts, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: desired,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !conflicts.Empty() {
+		t.Fatalf("expected no conflicts, got %+v", conflicts.Items())
+	}
+
+	sort.Strings(removed)
+	want := []string{
+		staleJSON,
+		staleJSON + ".monotool",
+		staleYAML,
+	}
+	if !equalSlices(removed, want) {
+		t.Fatalf("removed = %v, want %v", removed, want)
+	}
+}
+
+func TestPruneSkipsUnownedFiles(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	human := filepath.Join(targetDir, "human.yaml")
+	mustWrite(t, human, "kind: HumanFile\n")
+
+	removed, conflicts, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !conflicts.Empty() {
+		t.Fatalf("expected no conflicts, got %+v", conflicts.Items())
+	}
+	if len(removed) != 0 {
+		t.Fatalf("expected no removals, got %v", removed)
+	}
+	if _, err := os.Stat(human); err != nil {
+		t.Fatalf("human file was deleted: %v", err)
+	}
+}
+
+func TestPruneFlagsHashMismatchAsConflict(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	owned := filepath.Join(targetDir, "edited.yaml")
+	mustWriteMarked(t, owned, "kind: Original\n")
+	// Tamper.
+	cur, _ := os.ReadFile(owned)
+	if err := os.WriteFile(owned, append(cur, []byte("extra: true\n")...), 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, conflicts, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Force:      false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflicts.Empty() {
+		t.Fatal("expected a hash-mismatch conflict")
+	}
+	if len(removed) != 0 {
+		t.Fatalf("expected no removals without --force, got %v", removed)
+	}
+
+	// With --force, the file is left alone but the conflict is still reported.
+	removedF, conflictsF, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+		Force:      true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflictsF.Empty() {
+		t.Fatal("expected conflict to still be reported under --force")
+	}
+	if len(removedF) != 0 {
+		t.Fatalf("expected no removals (file is edited), got %v", removedF)
+	}
+}
+
+func TestPruneRemovesOrphanSidecar(t *testing.T) {
+	workDir := t.TempDir()
+	targetDir := filepath.Join(workDir, "apps/staging")
+	sidecar := filepath.Join(targetDir, "ghost.json.monotool")
+	mustWrite(t, sidecar, "deadbeef\n")
+
+	removed, conflicts, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !conflicts.Empty() {
+		t.Fatalf("orphan sidecar should not produce a conflict; got %+v", conflicts.Items())
+	}
+	if len(removed) != 1 || removed[0] != sidecar {
+		t.Fatalf("expected orphan sidecar removed, got %v", removed)
+	}
+}
+
+func TestPruneRemovesEmptyDirectories(t *testing.T) {
+	workDir := t.TempDir()
+	emptyAfter := filepath.Join(workDir, "apps/staging/leftovers")
+	stale := filepath.Join(emptyAfter, "x.yaml")
+	mustWriteMarked(t, stale, "kind: Stale\n")
+
+	if _, _, err := Prune(context.Background(), PruneOpts{
+		WorkDir:    workDir,
+		TargetPath: "apps/staging",
+		DesiredAbs: map[string]struct{}{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(emptyAfter); !os.IsNotExist(err) {
+		t.Fatalf("expected empty dir removed, got err=%v", err)
+	}
+}
+
+func mustWriteMarked(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownership.WriteMarked(path, []byte(body)); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
## Summary

Lets `monotool rollout` share its gitops repo with humans and other tools (ArgoCD writebacks, sealed-secrets operators, etc.) without overwriting or pruning their files. Adds two layers of safety on top of the previous unconditional `git add . && commit && push` flow:

- **File-level ownership markers** so monotool knows which files it wrote (and what their contents were the last time it wrote them).
- **Interactive y/n/abort prompting** under `--force` for every destructive action, with a non-TTY hard failure.

### Ownership markers

- YAML files carry `# monotool-hash: <sha256>` as the first line; JSON files use a sidecar `<file>.monotool` containing the hash.
- On rollout, each file is checked: unmarked → conflict (`unmarked`), marker hash mismatch → conflict (`hash-mismatch`). Without `--force` the rollout aborts with a per-file report; with `--force` each conflict is prompted for individually.
- Pruning (when `pruneTargets: true`) only deletes files monotool owns whose hash still matches. Hand-edited files are reported as conflicts and never deleted.
- Staging switches from `git add .` to explicit per-path `git add` / `git rm` — unrelated changes in the working tree are no longer scooped into the commit.
- When the rendered output is byte-identical to what monotool last wrote, the diff is empty and the commit/push/PR steps are skipped.

### Interactive `--force`

- New `rollout/confirm` package with a `Confirmer` callback (`func(action, path string) (bool, error)`) and a stdin-backed `TTYConfirmer`.
- Four prompt categories: `overwrite unmarked`, `overwrite edited`, `delete stale`, `remove orphan sidecar`.
- Y = proceed, N = skip just this one, A = abort the rollout. EOF on stdin = abort.
- `--force` without a TTY now returns `--force requires an interactive terminal`. The legacy non-interactive `--force` behavior is removed; CI use cases will need a separate mechanism (out of scope).
- User-initiated abort surfaces as `rollout aborted by user` with exit code 1 (no Go-style error wrap chain).

### Migration

Existing rollouts won't have markers on already-generated files. The first post-upgrade rollout will treat every file as `unmarked` and abort with a conflict report. Run once with `--force` to adopt the files; subsequent rollouts return to the normal safe mode.

## Design + plans

- [Coexistence spec](docs/superpowers/specs/2026-05-25-gitops-coexistence-design.md)
- [Coexistence plan](docs/superpowers/plans/2026-05-25-gitops-coexistence.md)
- [Interactive --force spec](docs/superpowers/specs/2026-05-26-force-interactive-confirm-design.md)
- [Interactive --force plan](docs/superpowers/plans/2026-05-26-force-interactive-confirm.md)

## Test plan

- [ ] CI: \`go build ./...\` clean
- [ ] CI: \`go test ./...\` passes (28 unit tests across rollout, rollout/confirm, rollout/conflict, rollout/ownership)
- [ ] CI: \`go vet ./...\` clean
- [ ] Manual: against a real gitops repo, run rollout once (sees \`unmarked\` conflicts), then with \`--force\` to adopt files; verify a human-edited file gets re-prompted and can be skipped, deleted, or overwritten as chosen
- [ ] Manual: \`--force < /dev/null\` should error out with the TTY requirement message

## New packages

- \`rollout/ownership\` — marker syntax (YAML header / JSON sidecar), hash, write/read/status/remove
- \`rollout/conflict\` — \`Set\` accumulator with \`Report\` (abort) and \`Warn\` (force) framings
- \`rollout/confirm\` — \`Confirmer\` callback, \`ErrAborted\` sentinel, \`TTYConfirmer\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)