### PR TITLE
docker: run go generate before building go module image

### DIFF
--- a/docker/buildgomod.go
+++ b/docker/buildgomod.go
@@ -69,6 +69,15 @@ func BuildGoMod(ctx context.Context, mainPackagePath string, imageName string, p
 	}
 	dockerRoot := mod.Dir
 
+	genCmd := exec.CommandContext(ctx, "go", "generate", "./...")
+	genCmd.Dir = dockerRoot
+	genOut := new(bytes.Buffer)
+	genCmd.Stdout = genOut
+	genCmd.Stderr = genOut
+	if err := genCmd.Run(); err != nil {
+		return fmt.Errorf("go generate ./... failed (%w):\n%s", err, genOut.String())
+	}
+
 	tempDockerfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return fmt.Errorf("could not create temp dockerfile: %w", err)


### PR DESCRIPTION
## Summary
- Run `go generate ./...` in the module directory before invoking `docker buildx build` for Go-module images, so any code generators run as part of the build pipeline.

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] Manual: run `monotool rollout` on a module containing `//go:generate` directives and confirm generated files are present in the resulting image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)